### PR TITLE
Migrate to TypeScript

### DIFF
--- a/TypeScript Implementation.md
+++ b/TypeScript Implementation.md
@@ -9,7 +9,7 @@ This is a play-by-play of how Steve Ognibene ([@nycdotnet](https://twitter.com/n
 
 I performed these tasks on Windows, but these tools are all open source and run great on Windows, Mac, and Linux.
 
-## Initial convert
+## Initial Convert
 1. Fork StatisticsParser on GitHub and clone it locally.  Open a command line to the local folder and run `atom .`  This opens a new instance of Atom to the root of the StatisticsParser folder.
 2. Under `src/assets/js/`, rename `statsioparser.js` to `statsioparser.ts`.
 3. The Atom-TypeScript tab will show on the bottom.  You should have one error - "No project file found. Please use the 'Create tsconfig.json' command".  Let's do that.
@@ -17,5 +17,46 @@ I performed these tasks on Windows, but these tools are all open source and run 
 5. Open and save your `statsioparser.ts` file.  This should create a `statsioparser.js` file again.  Congratulations - you have a working TypeScript implementation.
 6. I checked-in this code with the comment "Finished initial convert".
 
-## Fixing Initial errors
-1. After the initial convert (which I performed using all the latest TypeScript stuff in November 25, 2015), TypeScript reported 35 errors.  TypeScript doesn't distinguish errors from warnings, though, so despite these 35 errors, it emitted the JavaScript properly and everything should still work.  Don't worry about the count - this isn't so bad.
+After the initial convert (which I performed using all the latest TypeScript stuff in November 25, 2015), TypeScript reported 35 errors.  TypeScript doesn't distinguish errors from warnings, though, so despite these 35 errors, it emitted the JavaScript properly and everything should still work.  Don't worry about the count - this isn't so bad.  If you look at the changes in `statsioparser.js`, you'll see that the major differences after having gone through the TypeScript transpiler are changed whitespace, removal of comments (the default `tsconfig.json` in atom-typescript has `removeComments: true`), and adding semicolons where they were missing.  This is very important: **The code emitted by TypeScript looks almost exactly like the code you wrote**.
+
+## Fixing Type Errors
+TypeScript is sometimes cranky and getting it to compile existing JS code without complaining can sometimes take a bit of time.
+
+I see a lot of `Cannot find name $` errors.  TypeScript warns when a variable is used (`$` in this case) without it being declared, which is a good thing.  The `$` is jQuery.  TypeScript supports using definition files to interact with libraries that are written in pure JavaScript.  They allow describing the API of the JavaScript-based library in TypeScript, but definition files don't actually emit any code - they're only used at develop and compile time so there is no runtime cost.  Many JS libraries have been described in TypeScript definition files by the [DefinitelyTyped project](http://definitelytyped.org/).  They expose their library with a Node.js command-line tool `tsd`.
+
+1. Open your "Node.js" command-line.
+2. If you don't already have tsd, run `npm install -g tsd`.  That will install `tsd` globally (so it will work from any path in a Node.js command-line).
+3. Now that you have `tsd`, navigate to the StatisticsParser folder (same folder as the `Sample Query StackOverflow.sql`).
+4. Run `tsd init`.  This will create `tsd.json`, a `typings` folder and a `tsd.d.ts` file.
+5. Since we know we want jquery, let's search for that with tsd: `tsd query jquery`.  TSD will respond that it knows about jquery and it will show where it lives in the Definitely Typed repository.
+6. Let's install that definition in our project: `tsd query jquery --action install --save`.  That will install the definition in the `typings` folder and add `jquery` to the `tsd.json` file.
+7. One important thing that I didn't mention in the previous section is that it's most convenient for the `tsconfig.json` to live at the root of your project - so drag and drop tsconfig.json to the same folder as `tsd.json`.  This will adjust the compilation context to include the entire StatisticsParser folder structure.
+8. Go back to atom and open `statsioparser.ts`.  You may have to click the refresh circle in the lower-right, but now TypeScript should be down to 32 errors.  - Why didn't it go a lot lower?  Well, now TypeScript knows about `$`, but it doesn't think that `$.cookies` or `$().dataTable` are valid.  Let's fix those next.
+
+## Fixing Type Errors with DataTables (Somewhat Advanced)
+DefinitelyTyped has great type definitions for many, but not all JavaScript libraries.  In this section I'll describe how I got some of the definitions working that were missing or not-quite-right.
+
+1. I found that DefinitelyTyped did have a definition for [jQuery.Datatables](http://www.datatables.net/) by running `tsd query jquery.dataTables`, so I installed it via `tsd query jquery.dataTables --action install --save`.  However, this didn't fix any errors.  The reason is that StatisticsParser seems to be using an old syntax for jQuery.Datatables.  The syntax is supported in the definition but not fully exposed.  Let's fix that.
+2. Note in the error list for `statsioparser.ts`, it mentions that property `dataTable` does not exist on `JQuery`.  Let's fix that.
+3. Open `typings/jquery.dataTables/jquery.dataTables.d.ts`.  On line 14, add another property to JQuery for `dataTable`: `dataTable(param?: DataTables.Settings): DataTables.DataTable;`.  This changes the errors in `statsioparser.ts` to a type not assignable error.  This is because the lower-case `dataTable` seems to expect legacy parameters.  Thankfully, the legacy parameters are still defined in the definition in an interface called `SettingsLegacy`.  Change the type of `param` to `DataTables.SettingsLegacy`.  Also (unfortunately), it's necessary to mark all properties of SettingsLegacy as optional - because technically it is a property bag. For example, line 1661 should be changed to `ajax?: any;`.  Change all of the properties to optional.
+4. Now the error is somewhat different (you may have to expand the twisty to see both lines of the error) - Object literal may only specify known properties, and bFilter does not exist in type SettingsLegacy.  This is true, but it does exist in `FeaturesLegacy`.  So let's update the `dataTable` param to accept a `DataTables.SettingsLegacy` unioned with a `DataTables.FeaturesLegacy`.   Change line 15 to `dataTable(param?: DataTables.SettingsLegacy | DataTables.FeaturesLegacy): DataTables.DataTable;`  You'll also have to mark the properties of `FeaturesLegacy` as optional.
+5. One error is gone, but there is still another in `statsioparser.ts`: `sScrollY` does not exist.  Let's add `sScrollY` to the SettingsLegacy interface: `sScrollY?: string;`.  We get a similar error for `bScrollCollapse` - let's add that.  `bScrollCollapse?: boolean;`
+6. Great - all of our DataTables errors are gone.  These could probably have all been in the actual definition on DefinitelyTyped, so it may be worth contributing these fixes back.
+
+## Fixing Numeral and Cookies errors
+I was unable to find definitions for Numeral or Cookies on DefinitelyTyped.  The easiest way to accept this and move on is to create a definition file for them and just stub their global objects as type `any`.  The paths and file names in this section are optional, but they will work with how `tsd` does it if the definitions are ever contributed back.
+
+1. Create a new folder under typings called `jaaulde-jquery-cookies` with a file called `jaaulde-jquery-cookies.d.ts`.  This follows the convention to use the `npm` ID of the package as the definition folder name.  In `jaaulde-jquery-cookies.d.ts`, add this content:
+
+```TypeScript
+interface JQueryStatic {
+    cookies?: any;
+}
+```
+
+2. Create a new folder under typings called `numeral`.  In there, create a new file called `numeral.d.ts`.  Add the following content:
+```TypeScript
+declare var numeral: any;
+```
+
+It's possible to add more explicit typing info to these definitions, but this will get us compiling cleanly for now.

--- a/TypeScript Implementation.md
+++ b/TypeScript Implementation.md
@@ -1,0 +1,21 @@
+# StatisticsParser to TypeScript
+
+This is a play-by-play of how Steve Ognibene ([@nycdotnet](https://twitter.com/nycdotnet/)) converted StatisticsParser to TypeScript.
+
+## Prerequisites
+1. Prior to starting, I installed [Atom](https://atom.io/) and the [atom-typescript](https://atom.io/packages/atom-typescript) plugin (via the Packages tab under File... Settings).  There are many other editors that support TypeScript, but I like Atom best for getting started.
+2. This is completely optional, but if you like the look of Visual Studio, install [Redmond-UI](https://atom.io/themes/redmond-ui) and [Redmond-Syntax](https://atom.io/themes/redmond-syntax).
+3. I also installed [Node.js](https://nodejs.org/) - the latest on 4.x or 5.x is fine - to allow the use of standard TypeScript command-line tools.
+
+I performed these tasks on Windows, but these tools are all open source and run great on Windows, Mac, and Linux.
+
+## Initial convert
+1. Fork StatisticsParser on GitHub and clone it locally.  Open a command line to the local folder and run `atom .`  This opens a new instance of Atom to the root of the StatisticsParser folder.
+2. Under `src/assets/js/`, rename `statsioparser.js` to `statsioparser.ts`.
+3. The Atom-TypeScript tab will show on the bottom.  You should have one error - "No project file found. Please use the 'Create tsconfig.json' command".  Let's do that.
+4. Press CTRL+SHIFT+P and type tsconfig in the command palate.  Click "TypeScript: Create Tsconfig.json Project File".
+5. Open and save your `statsioparser.ts` file.  This should create a `statsioparser.js` file again.  Congratulations - you have a working TypeScript implementation.
+6. I checked-in this code with the comment "Finished initial convert".
+
+## Fixing Initial errors
+1. After the initial convert (which I performed using all the latest TypeScript stuff in November 25, 2015), TypeScript reported 35 errors.  TypeScript doesn't distinguish errors from warnings, though, so despite these 35 errors, it emitted the JavaScript properly and everything should still work.  Don't worry about the count - this isn't so bad.

--- a/src/assets/js/statsioparser.ts
+++ b/src/assets/js/statsioparser.ts
@@ -1,6 +1,6 @@
 
 function includeExample(value, lang) {
-    var txt = document.getElementById("statiotext");
+    var txt = <HTMLTextAreaElement>document.getElementById("statiotext");
     if (value == true) {
         txt.value = lang.sampleoutput;
     } else {
@@ -37,7 +37,7 @@ var rowEnum = {
     Error: 5
 }
 
-function statsIOInfo(rownumber, langText, table, scan, logical, physical, readahead, loblogical, lobphysical, lobreadahead) {
+function statsIOInfo(rownumber, langText, table, scan?, logical?, physical?, readahead?, loblogical?, lobphysical?, lobreadahead?) {
     this.rownumber = rownumber;
     this.table = table;
     this.nostats = false;
@@ -261,7 +261,7 @@ function parseOutput(txt, lang) {
 
 function parseText(lang) {
 
-    var formattedOutput = parseOutput( document.getElementById("statiotext").value, lang);
+    var formattedOutput = parseOutput( (<HTMLTextAreaElement>document.getElementById("statiotext")).value, lang);
 
     document.getElementById("result").innerHTML = formattedOutput.output;
     document.getElementById("clearButton").innerHTML  = 'Clear Results';
@@ -473,8 +473,8 @@ function clearResult() {
     if (document.getElementById("result").innerHTML != '') {
         document.getElementById("result").innerHTML = '';
     } else {
-       document.getElementById("statiotext").value = '';
-       document.getElementById("exampleCheck").checked = false;
+       (<HTMLTextAreaElement>document.getElementById("statiotext")).value = '';
+       (<HTMLInputElement>document.getElementById("exampleCheck")).checked = false;
     }
     document.getElementById("clearButton").innerHTML = 'Clear Text';
 }

--- a/src/assets/js/statsioparser.ts
+++ b/src/assets/js/statsioparser.ts
@@ -1,32 +1,33 @@
+
 function includeExample(value, lang) {
     var txt = document.getElementById("statiotext");
     if (value == true) {
         txt.value = lang.sampleoutput;
-    }
-    else {
+    } else {
         txt.value = "";
     }
 }
+
 function updateQueryStringParameter(uri, key, value) {
     var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
     var separator = uri.indexOf('?') !== -1 ? "&" : "?";
     if (uri.match(re)) {
         return uri.replace(re, '$1' + key + "=" + value + '$2');
-    }
-    else {
+    } else {
         return uri + separator + key + "=" + value;
     }
 }
+
 function toggleCheckmark(checkmarkSpan, cookieKey) {
-    if ($.cookies.get(cookieKey) === true) {
+    if($.cookies.get(cookieKey) === true) {
         $.cookies.set(cookieKey, "false");
         checkmarkSpan.style.display = 'none';
-    }
-    else {
+    } else {
         $.cookies.set(cookieKey, "true");
         checkmarkSpan.style.display = '';
     }
 }
+
 var rowEnum = {
     None: 0,
     IO: 1,
@@ -34,7 +35,8 @@ var rowEnum = {
     CompileTime: 3,
     RowsAffected: 4,
     Error: 5
-};
+}
+
 function statsIOInfo(rownumber, langText, table, scan, logical, physical, readahead, loblogical, lobphysical, lobreadahead) {
     this.rownumber = rownumber;
     this.table = table;
@@ -48,6 +50,7 @@ function statsIOInfo(rownumber, langText, table, scan, logical, physical, readah
     this.lobreadahead = infoReplace(lobreadahead, langText.lobreadahead, '');
     this.percentread = 0.0;
 }
+
 function statsIOInfoTotal() {
     this.rownumber = 0;
     this.table = '';
@@ -60,45 +63,44 @@ function statsIOInfoTotal() {
     this.lobreadahead = 0;
     this.percentread = 0.0;
 }
+
 function statsTimeInfo(cpu, elapsed) {
     this.cpu = parseInt(cpu);
     this.elapsed = parseInt(elapsed);
 }
+
 function statsTimeInfoTotal() {
     this.cpu = 0;
     this.elapsed = 0;
 }
-function determineLang(strRow) {
+
+function determineLang(strRow){
     var lang = 1;
-    if (strRow.substring(0, 7) === 'Table \'') {
-        lang = 1;
-    }
-    else if (strRow.substring(0, 7) === 'Tabla \'') {
-        lang = 2;
-    }
-    else if ($.trim(strRow.substring(0, 6)) === 'Tiempo') {
-        lang = 2;
-    }
-    else if ($.trim(strRow.substring(0, 7)) === 'Tiempos') {
-        lang = 2;
-    }
+
+    if (strRow.substring(0,7) === 'Table \'') { lang = 1; } // English
+    else if (strRow.substring(0, 7) === 'Tabla \'') { lang = 2; } // Spanish
+    else if ($.trim(strRow.substring(0, 6)) === 'Tiempo') { lang = 2; } // Spanish
+    else if ($.trim(strRow.substring(0, 7)) === 'Tiempos') { lang = 2; } // Spanish
+
     return lang;
 }
-function determineLangFilename(langType) {
+
+function determineLangFilename (langType) {
     var filename;
-    switch (langType) {
-        case 'en':
-            filename = 'assets/data/languagetext-en.json';
+    switch(langType) {
+        case 'en': // English
+            filename = 'assets/data/languagetext-en.json'
             break;
-        case 'es':
-            filename = 'assets/data/languagetext-es.json';
+        case 'es': // Spanish
+            filename = 'assets/data/languagetext-es.json'
             break;
-        default:
-            filename = 'assets/data/languagetext-en.json';
+        default :
+            filename = 'assets/data/languagetext-en.json'
             break;
     }
     return filename;
 }
+
 function infoReplace(strValue, searchValue, newvValue) {
     var returnValue = 0;
     if (strValue != undefined) {
@@ -109,39 +111,47 @@ function infoReplace(strValue, searchValue, newvValue) {
     }
     return returnValue;
 }
+
 function determineRowType(strRow, langText) {
     var rowType = rowEnum.None;
+
     if (strRow.substring(0, 7) === langText.table) {
         rowType = rowEnum.IO;
-    }
-    else if ($.trim(strRow) === langText.executiontime) {
+    } else if ($.trim(strRow) === langText.executiontime) {
         rowType = rowEnum.ExectuionTime;
-    }
-    else if ($.trim(strRow) === langText.compiletime) {
+    } else if ($.trim(strRow) === langText.compiletime) {
         rowType = rowEnum.CompileTime;
-    }
-    else if (strRow.indexOf(langText.rowsaffected) > -1) {
+    } else if (strRow.indexOf(langText.rowsaffected) > -1) {
         rowType = rowEnum.RowsAffected;
-    }
-    else if (strRow.substring(0, 3) === langText.errormsg) {
+    } else if (strRow.substring(0,3) === langText.errormsg) {
         rowType = rowEnum.Error;
     }
+
     return rowType;
 }
+
 function processTimeRegEx(preText, postText) {
     var re = new RegExp("(.*" + preText + "+)(.*?)(\\s+" + postText + ".*)");
-    return re;
+
+    return re
 }
+
 function processTime(line, cputime, elapsedtime, milliseconds) {
     var section = line.split(',');
+
     var re = processTimeRegEx(cputime, milliseconds);
     var re2 = processTimeRegEx(elapsedtime, milliseconds);
-    return new statsTimeInfo(section[0].replace(re, "$2"), section[1].replace(re2, "$2"));
+
+    return new statsTimeInfo(section[0].replace(re, "$2"), section[1].replace(re2, "$2"))
 }
+
 function processIOTableRow(line, tableResult, langText) {
     var section = line.split('\.');
-    var tableName = getSubStr(section[0], '\'');
+    var tableName = getSubStr(section[0], '\'')
     var tableData = section[1];
+
+    // If not a statistics IO statement then end table (if necessary) and write line ending in <br />
+    // If prev line was not a statistics IO statement then start a table.
     if (tableData != undefined) {
         if (tableData == '') {
             var statLineInfo = new statsIOInfo(tableResult.length + 1, langText, line);
@@ -151,8 +161,7 @@ function processIOTableRow(line, tableResult, langText) {
         var stat = tableData.split(/[,]+/);
         var statInfo = new statsIOInfo(tableResult.length + 1, langText, tableName, stat[0], stat[1], stat[2], stat[3], stat[4], stat[5], stat[6]);
         tableResult.push(statInfo);
-    }
-    else {
+    } else {
         if (line.length > 0) {
             var statLineInfo = new statsIOInfo(tableResult.length + 1, langText, line);
             statLineInfo.nostats = true;
@@ -160,7 +169,9 @@ function processIOTableRow(line, tableResult, langText) {
         }
     }
 }
+
 function parseOutput(txt, lang) {
+    //var txt = document.getElementById("statiotext").value;
     var lines = txt.split('\n');
     var tableIOResult = new Array();
     var executionTotal = new statsTimeInfoTotal();
@@ -171,17 +182,19 @@ function parseOutput(txt, lang) {
     var isCompile = false;
     var isError = false;
     var formattedOutput = '';
+
     for (var i = 0; i < lines.length; i++) {
         var line = lines[i];
+
         if (isExecution === false && isCompile === false && isError === false) {
             var rowType = determineRowType(line, lang);
         }
+
         switch (rowType) {
             case rowEnum.IO:
                 if (inTable === true) {
                     processIOTableRow(line, tableIOResult, lang);
-                }
-                else {
+                } else {
                     tableCount += 1;
                     inTable = true;
                     processIOTableRow(line, tableIOResult, lang);
@@ -190,22 +203,22 @@ function parseOutput(txt, lang) {
             case rowEnum.ExectuionTime:
                 if (isExecution === true) {
                     var et = processTime(line, lang.cputime, lang.elapsedtime, lang.milliseconds);
-                    formattedOutput += outputTimeTable(et, lang.executiontime, lang.milliseconds, lang.elapsedlabel, lang.cpulabel);
+                    formattedOutput += outputTimeTable(et, lang.executiontime, lang.milliseconds, lang.elapsedlabel, lang.cpulabel)
                     executionTotal.cpu += et.cpu;
-                    executionTotal.elapsed += et.elapsed;
-                }
-                else {
+                    executionTotal.elapsed += et.elapsed
+                } else {
+                    //formattedOutput += '<span>' + line + '<br /></span>';
                 }
                 isExecution = !isExecution;
                 break;
             case rowEnum.CompileTime:
                 if (isCompile === true) {
                     var ct = processTime(line, lang.cputime, lang.elapsedtime, lang.milliseconds);
-                    formattedOutput += outputTimeTable(ct, lang.compiletime, lang.milliseconds, lang.elapsedlabel, lang.cpulabel);
+                    formattedOutput += outputTimeTable(ct, lang.compiletime, lang.milliseconds, lang.elapsedlabel, lang.cpulabel)
                     compileTotal.cpu += ct.cpu;
-                    compileTotal.elapsed += ct.elapsed;
-                }
-                else {
+                    compileTotal.elapsed += ct.elapsed
+                } else {
+                    //formattedOutput += '<span>' + line + '<br /></span>';
                 }
                 isCompile = !isCompile;
                 break;
@@ -222,7 +235,7 @@ function parseOutput(txt, lang) {
                 break;
             case rowEnum.Error:
                 isError = (isError === false ? true : false);
-                formattedOutput += '<div class="error-text">' + line + '</div>';
+                formattedOutput += '<div class="error-text">' + line + '</div>'
                 break;
             default:
                 if (inTable === true) {
@@ -232,63 +245,74 @@ function parseOutput(txt, lang) {
                 }
                 formattedOutput += '<span>' + line + '<br /></span>';
         }
+
     }
+
+    // if last row a table then call formatOutput
     if (inTable == true) {
         formattedOutput += outputIOTable(tableIOResult, statsIOCalcTotals(tableIOResult), tableCount, lang);
     }
-    formattedOutput += '<h4>Totals:</h4>';
+
+    formattedOutput += '<h4>Totals:</h4>'
     formattedOutput += outputTimeTableTotals(executionTotal, compileTotal, lang.compiletime, lang.executiontime, lang.milliseconds, lang.elapsedlabel, lang.cpulabel);
-    return { output: formattedOutput, tableCount: tableCount };
+
+    return {output: formattedOutput, tableCount: tableCount}
 }
+
 function parseText(lang) {
-    var formattedOutput = parseOutput(document.getElementById("statiotext").value, lang);
+
+    var formattedOutput = parseOutput( document.getElementById("statiotext").value, lang);
+
     document.getElementById("result").innerHTML = formattedOutput.output;
-    document.getElementById("clearButton").innerHTML = 'Clear Results';
+    document.getElementById("clearButton").innerHTML  = 'Clear Results';
+
+    //Apply datatables plugin
     for (var counter = 1; counter <= formattedOutput.tableCount; counter++) {
-        if ($.cookies.get("tableScrollbar") == true) {
-            $('#resultTable' + counter).dataTable({
-                "sDom": "t",
-                "bFilter": false,
-                "bPaginate": false,
-                "sScrollY": "200px",
-                "bScrollCollapse": false,
-                "aoColumns": [
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    null,
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" }
-                ]
-            });
-        }
-        else {
-            $('#resultTable' + counter).dataTable({
-                "sDom": "t",
-                "bFilter": false,
-                "bPaginate": false,
-                "aoColumns": [
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    null,
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" },
-                    { "sType": "formatted-num", "sClass": "td-column-right" }
-                ]
-            });
+        if($.cookies.get("tableScrollbar") == true) {
+        $('#resultTable' + counter).dataTable({
+            "sDom": "t",
+            "bFilter": false,
+            "bPaginate": false,
+            "sScrollY": "200px",
+            "bScrollCollapse": false,
+            "aoColumns": [
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                null,
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" }
+            ]
+        });
+        } else {
+        $('#resultTable' + counter).dataTable({
+            "sDom": "t",
+            "bFilter": false,
+            "bPaginate": false,
+            "aoColumns": [
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                null,
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" },
+                { "sType": "formatted-num", "sClass": "td-column-right" }
+            ]
+        });
         }
     }
 }
+
 function statsIOCalcTotals(statInfos) {
     var statTotal = new statsIOInfoTotal();
+
     for (var i = 0; i < statInfos.length; i++) {
         statTotal.scan += statInfos[i].scan;
         statTotal.logical += statInfos[i].logical;
@@ -301,58 +325,78 @@ function statsIOCalcTotals(statInfos) {
     calcPercent(statInfos, statTotal);
     return statTotal;
 }
+
 function calcPercent(statInfos, statTotal) {
     for (var i = 0; i < statInfos.length; i++) {
         statInfos[i].percentread = ((statInfos[i].logical / statTotal.logical) * 100).toFixed(3);
+        //statInfos[i].percentread += statInfos[i].percentread.toString() + '%';
     }
 }
-function formatms(milliseconds) {
-    return moment.utc(milliseconds).format("HH:mm:ss.SSS");
+
+function formatms (milliseconds) {
+    return moment.utc(milliseconds).format("HH:mm:ss.SSS")
 }
+
 function outputTimeTable(timeValues, langTitle, langDuration, elapsedLabel, cpuLabel) {
     var result = '<div style="padding-top:10px"><table class="table table-striped table-hover table-condensed table-nonfluid"">';
     result += '<thead><tr>';
     result += '<th class="th-column td-column-timetype"></th>';
+    //result += '<th class="th-column td-column-right"> ' + cpuLabel + ' (' + langDuration + ')</th>';
+    //result += '<th class="th-column td-column-right"> ' + elapsedLabel + ' (' + langDuration + ')</th>';
     result += '<th class="th-column td-column-right"> ' + cpuLabel + '</th>';
     result += '<th class="th-column td-column-right"> ' + elapsedLabel + '</th>';
     result += '</tr></thead>';
     result += '<tbody>';
     result += '<tr>';
-    result += '<td class="td-column-timetype">' + langTitle + '</td>';
-    ;
+    result += '<td class="td-column-timetype">' + langTitle + '</td>';;
+    //result += '<td class="td-column-right">' + numeral(timeValues.cpu).format('0,0') + '</td>';
+    //result += '<td class="td-column-right">' + numeral(timeValues.elapsed).format('0,0') + '</td>';
     result += '<td class="td-column-right">' + formatms(timeValues.cpu) + '</td>';
     result += '<td class="td-column-right">' + formatms(timeValues.elapsed) + '</td>';
     result += '</tr></tbody></table><div>';
+
     return result;
 }
+
 function outputTimeTableTotals(executionValues, compileValues, langCompileTitle, langExecutionTitle, langDuration, elapsedLabel, cpuLabel) {
-    var cpuTotal = parseInt(executionValues.cpu) + parseInt(compileValues.cpu);
-    var elapsedTotal = parseInt(executionValues.elapsed) + parseInt(compileValues.elapsed);
+    var cpuTotal = parseInt(executionValues.cpu) + parseInt(compileValues.cpu)
+    var elapsedTotal = parseInt(executionValues.elapsed) + parseInt(compileValues.elapsed)
+
     var result = '<div style="padding-top:10px"><table class="table table-striped table-hover table-condensed table-nonfluid">';
     result += '<thead><tr>';
     result += '<th class="th-column td-column-timetype"></th>';
+    //result += '<th class="th-column td-column-right"> ' + cpuLabel + ' (' + langDuration + ')</th>';
+    //result += '<th class="th-column td-column-right"> ' + elapsedLabel + ' (' + langDuration + ')</th>';
     result += '<th class="th-column td-column-right"> ' + cpuLabel + '</th>';
     result += '<th class="th-column td-column-right"> ' + elapsedLabel + '</th>';
     result += '</tr></thead>';
     result += '<tbody>';
     result += '<tr>';
     result += '<td class="td-column-timetype">' + langCompileTitle + '</td>';
+    //result += '<td class="td-column-right">' + numeral(compileValues.cpu).format('0,0') + '</td>';
+    //result += '<td class="td-column-right">' + numeral(compileValues.elapsed).format('0,0') + '</td>';
     result += '<td class="td-column-right">' + formatms(compileValues.cpu) + '</td>';
     result += '<td class="td-column-right">' + formatms(compileValues.elapsed) + '</td>';
     result += '</tr><tr>';
     result += '<td class="td-column-timetype">' + langExecutionTitle + '</td>';
+    //result += '<td class="td-column-right">' + numeral(executionValues.cpu).format('0,0') + '</td>';
+    //result += '<td class="td-column-right">' + numeral(executionValues.elapsed).format('0,0') + '</td>';
     result += '<td class="td-column-right">' + formatms(executionValues.cpu) + '</td>';
     result += '<td class="td-column-right">' + formatms(executionValues.elapsed) + '</td>';
     result += '</tr></tbody>';
     result += '<tfoot><tr>';
     result += '<td class="td-total td-column-timetype">Total</td>';
+    //result += '<td class="td-total td-column-right">' + numeral(cpuTotal).format('0,0') + '</td>';
+    //result += '<td class="td-total td-column-right">' + numeral(elapsedTotal).format('0,0') + '</td>';
     result += '<td class="td-total td-column-right">' + formatms(cpuTotal) + '</td>';
     result += '<td class="td-total td-column-right">' + formatms(elapsedTotal) + '</td>';
     result += '</tr></tfoot></table><div>';
+
     return result;
 }
-function outputIOTable(statInfo, statTotal, tableNumber, langObj) {
-    var result = '<table id="resultTable' + tableNumber + '" class="table table-striped table-hover table-condensed" style="table-layout:fixed">';
+
+ function outputIOTable(statInfo, statTotal, tableNumber, langObj) {
+    var result = '<table id="resultTable' + tableNumber +'" class="table table-striped table-hover table-condensed" style="table-layout:fixed">';
     result += '<thead><tr>';
     result += '<th class="th-column column-small">' + langObj.headerrownum + '</th>';
     result += '<th class="th-column">' + langObj.headertable + '</th>';
@@ -368,6 +412,7 @@ function outputIOTable(statInfo, statTotal, tableNumber, langObj) {
     result += '<tbody>';
     for (var i = 0; i < statInfo.length; i++) {
         result += '<tr>';
+
         result += '<td>' + statInfo[i].rownumber + '</td>';
         result += '<td>' + statInfo[i].table + '</td>';
         if (statInfo[i].nostats) {
@@ -379,8 +424,7 @@ function outputIOTable(statInfo, statTotal, tableNumber, langObj) {
             result += '<td></td>';
             result += '<td></td>';
             result += '<td></td>';
-        }
-        else {
+        } else {
             result += '<td>' + numeral(statInfo[i].scan).format('0,0') + '</td>';
             result += '<td>' + numeral(statInfo[i].logical).format('0,0') + '</td>';
             result += '<td>' + numeral(statInfo[i].physical).format('0,0') + '</td>';
@@ -405,28 +449,36 @@ function outputIOTable(statInfo, statTotal, tableNumber, langObj) {
     result += '<td class="footer-column column-medium">' + numeral(statTotal.lobreadahead).format('0,0') + '</td>';
     result += '<td class="footer-column column-xlarge">&nbsp;</td>';
     result += '</tr></tfoot>';
-    result += '</table>';
+
+    result += '</table>'
+
     return result;
 }
+
 function getSubStr(str, delim) {
     var a = str.indexOf(delim);
+
     if (a == -1)
         return '';
+
     var b = str.indexOf(delim, a + 1);
+
     if (b == -1)
         return '';
+
     return str.substr(a + 1, b - a - 1);
 }
+
 function clearResult() {
     if (document.getElementById("result").innerHTML != '') {
         document.getElementById("result").innerHTML = '';
-    }
-    else {
-        document.getElementById("statiotext").value = '';
-        document.getElementById("exampleCheck").checked = false;
+    } else {
+       document.getElementById("statiotext").value = '';
+       document.getElementById("exampleCheck").checked = false;
     }
     document.getElementById("clearButton").innerHTML = 'Clear Text';
 }
+
 function versionNumber() {
     document.getElementById("versionNumber").innerHTML = '0.4.4';
 }

--- a/src/assets/js/tsconfig.json
+++ b/src/assets/js/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "isolatedModules": false,
+        "jsx": "react",
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "declaration": false,
+        "noImplicitAny": false,
+        "removeComments": true,
+        "noLib": false,
+        "preserveConstEnums": true,
+        "suppressImplicitAnyIndexErrors": true
+    },
+    "filesGlob": [
+        "**/*.ts",
+        "**/*.tsx",
+        "!node_modules/**"
+    ],
+    "files": [
+        "statsioparser.ts"
+    ],
+    "atom": {
+        "rewriteTsconfig": true
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,12 @@
         "!node_modules/**"
     ],
     "files": [
-        "statsioparser.ts"
+        "src/assets/js/statsioparser.ts",
+        "typings/jaaulde-jquery-cookies/jaaulde-jquery-cookies.d.ts",
+        "typings/jquery.dataTables/jquery.dataTables.d.ts",
+        "typings/jquery/jquery.d.ts",
+        "typings/numeral/numeral.d.ts",
+        "typings/tsd.d.ts"
     ],
     "atom": {
         "rewriteTsconfig": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
         "typings/jaaulde-jquery-cookies/jaaulde-jquery-cookies.d.ts",
         "typings/jquery.dataTables/jquery.dataTables.d.ts",
         "typings/jquery/jquery.d.ts",
+        "typings/moment/moment.d.ts",
         "typings/numeral/numeral.d.ts",
         "typings/tsd.d.ts"
     ],

--- a/tsd.json
+++ b/tsd.json
@@ -1,0 +1,15 @@
+{
+  "version": "v4",
+  "repo": "borisyankov/DefinitelyTyped",
+  "ref": "master",
+  "path": "typings",
+  "bundle": "typings/tsd.d.ts",
+  "installed": {
+    "jquery/jquery.d.ts": {
+      "commit": "36c6ce86fb64bafb28ec95dc78c6b98228b45c8d"
+    },
+    "jquery.dataTables/jquery.dataTables.d.ts": {
+      "commit": "36c6ce86fb64bafb28ec95dc78c6b98228b45c8d"
+    }
+  }
+}

--- a/tsd.json
+++ b/tsd.json
@@ -10,6 +10,12 @@
     },
     "jquery.dataTables/jquery.dataTables.d.ts": {
       "commit": "36c6ce86fb64bafb28ec95dc78c6b98228b45c8d"
+    },
+    "moment/moment.d.ts": {
+      "commit": "36c6ce86fb64bafb28ec95dc78c6b98228b45c8d"
+    },
+    "moment/moment-node.d.ts": {
+      "commit": "36c6ce86fb64bafb28ec95dc78c6b98228b45c8d"
     }
   }
 }

--- a/typings/jaaulde-jquery-cookies/jaaulde-jquery-cookies.d.ts
+++ b/typings/jaaulde-jquery-cookies/jaaulde-jquery-cookies.d.ts
@@ -1,0 +1,3 @@
+interface JQueryStatic {
+    cookies?: any;
+}

--- a/typings/jquery.dataTables/jquery.dataTables.d.ts
+++ b/typings/jquery.dataTables/jquery.dataTables.d.ts
@@ -1,0 +1,1838 @@
+﻿// Type definitions for JQuery DataTables 1.10.5
+// Project: http://www.datatables.net
+// Definitions by: Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>, Omid Rad <https://github.com/omidkrad>, Armin Sander <https://github.com/pragmatrix/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// missing:
+// - Static methods that are defined in JQueryStatic.fn are not typed.
+// - Plugin and extension definitions are not typed.
+// - Some return types are not fully wokring
+
+/// <reference path="../jquery/jquery.d.ts"/>
+
+interface JQuery {
+    DataTable(param?: DataTables.Settings): DataTables.DataTable;
+    dataTable(param?: DataTables.SettingsLegacy | DataTables.FeaturesLegacy): DataTables.DataTable;
+}
+
+//TODO: Wrong, as jquery.d.ts has no interface for fn
+//interface JQueryStatic {
+//    dataTable: DataTables.StaticFunctions;
+//}
+
+declare module DataTables {
+    export interface DataTable extends DataTableCore {
+        /**
+        * Get the data for the whole table.
+        */
+        data(): DataTable;
+
+        /**
+        * Order Methods / Object
+        */
+        order: OrderMethods;
+
+        //#region "Cell/Cells"
+
+        /**
+        * Select the cell found by a cell selector
+        *
+        * @param cellSelector Cell selector.
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        cell(cellSelector: (string | Node | Function | JQuery | Object) | (string | Node | Function | JQuery | Object)[], modifier?: ObjectSelectorModifier): CellMethods;
+
+        /**
+        * Select the cell found by a cell selector
+        *
+        * @param rowSelector Row selector.
+        * @param cellSelector Cell selector.
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        cell(rowSelector: (string | Node | Function | JQuery | Object) | (string | Node | Function | JQuery | Object)[], cellSelector: (string | Node | Function | JQuery | Object) | (string | Node | Function | JQuery | Object)[], modifier?: ObjectSelectorModifier): CellMethods;
+
+        /**
+        * Select all cells
+        *
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        cells(modifier?: ObjectSelectorModifier): CellsMethods;
+
+        /**
+        * Select cells found by a cell selector
+        *
+        * @param cellSelector Cell selector.
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        cells(cellSelector: (string | Node | Function | JQuery | Object) | (string | Node | Function | JQuery | Object)[], modifier?: ObjectSelectorModifier): CellsMethods;
+
+        /**
+        * Select cells found by both row and column selectors
+        *
+        * @param rowSelector Row selector.
+        * @param cellSelector Cell selector.
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        cells(rowSelector: (string | Node | Function | JQuery | Object) | (string | Node | Function | JQuery | Object)[], cellSelector: (string | Node | Function | JQuery | Object) | (string | Node | Function | JQuery | Object)[], modifier?: ObjectSelectorModifier): CellsMethods;
+        //#endregion "Cell/Cells"
+
+        //#region "Column/Columns"
+
+        /**
+        * Column Methods / Object
+        */
+        column: ColumnMethodsModel;
+
+        /**
+        * Columns Methods / Object
+        */
+        columns: ColumnsMethodsModel;
+
+        //#endregion "Column/Columns"
+
+        //#region "Row/Rows"
+
+        /**
+        * Row Methode / Object
+        */
+        row: RowMethodsModel
+
+        /**
+        * Rows Methods / Object
+        */
+        rows: RowsMethodsModel
+
+        //#endregion "Row/Rows"
+
+        //#region "Table/Tables"
+
+        /**
+        * Select a table based on a selector from the API's context
+        *
+        * @param tableSelector Table selector.
+        */
+        table(tableSelector: (string | Node | Function | JQuery | Object) | (string | Node | Function | JQuery | Object)[]): TableMethods;
+
+        /**
+        * Select all tables
+        */
+        tables(): TablesMethods;
+
+        /**
+        * Select tables based on the given selector
+        *
+        * @param tableSelector Table selector.
+        */
+        tables(tableSelector: (string | Node | Function | JQuery | Object) | (string | Node | Function | JQuery | Object)[]): TablesMethods;
+
+        //#endregion "Table/Tables"
+    }
+
+    export interface DataTables extends DataTableCore {
+        [index: number]: DataTable;
+    }
+
+    interface ObjectSelectorModifier {
+        /**
+        * The order modifier provides the ability to control which order the rows are processed in.
+        * Values: 'current', 'applied', 'index',  'original'
+        */
+        order?: string;
+
+        /**
+        * The search modifier provides the ability to govern which rows are used by the selector using the search options that are applied to the table.
+        * Values: 'none', 'applied', 'removed'
+        */
+        search?: string;
+
+        /**
+        * The page modifier allows you to control if the selector should consider all data in the table, regardless of paging, or if only the rows in the currently disabled page should be used.
+        * Values: 'all', 'current'
+        */
+        page?: string;
+    }
+
+    //#region "Namespaces"
+
+    //#region "core-methods"
+
+    interface DataTableCore extends UtilityMethods {
+        /**
+        * Get jquery object
+        */
+        $(selector: string | Node | Node[]| JQuery, modifier?: ObjectSelectorModifier): JQuery;
+
+        ///// Almost identical to $ in operation, but in this case returns the data for the matched rows.
+        //_(selector: string | Node | Node[] | JQuery, modifier?: ObjectSelectorModifier): JQuery;
+
+        /**
+        * Ajax Methods
+        */
+        ajax: AjaxMethodModel;
+
+        /**
+        * Clear the table of all data.
+        */
+        clear(): DataTable;
+
+        /**
+        * Destroy the DataTables in the current context.
+        *
+        * @param remove Completely remove the table from the DOM (true) or leave it in the DOM in its original plain un-enhanced HTML state (default, false).
+        */
+        destroy(remove?: boolean): DataTable;
+
+        /**
+        * Redraw the table.
+        *
+        * @param reset Reset (default) or hold the current paging position. A full re-sort and re-filter is performed when this method is called, which is why the pagination reset is the default action.
+        */
+        draw(reset?: boolean): DataTable;
+
+        /**
+        * Table events removal.
+        *
+        * @param event Event name to remove.
+        * @param callback Specific callback function to remove if you want to unbind a single event listener.
+        */
+        off(event: string, callback?: Function): DataTable;
+
+        /**
+        * Table events listener.
+        *
+        * @param event Event to listen for.
+        * @param callback Specific callback function to remove if you want to unbind a single event listener.
+        */
+        on(event: string, callback: Function): DataTable;
+
+        /**
+        * Listen for a table event once and then remove the listener.
+        *
+        * @param event Event to listen for.
+        * @param callback Specific callback function to remove if you want to unbind a single event listener.
+        */
+        one(event: string, callback: Function): DataTable;
+
+        /**
+        * Page Methods / Object
+        */
+        page: PageMethods;
+
+        /**
+        * Get current search
+        */
+        search(): string;
+
+        /**
+        * Search for data in the table.
+        *
+        * @param input Search string to apply to the table.
+        * @param regex Treat as a regular expression (true) or not (default, false).
+        * @param smart Perform smart search.
+        * @param caseInsen Do case-insensitive matching (default, true) or not (false).
+        */
+        search(input: string, regex?: boolean, smart?: boolean, caseInsen?: boolean): DataTable;
+
+        /**
+        * Obtain the table's settings object
+        */
+        settings(): DataTable;
+
+        /**
+        * Page Methods / Object
+        */
+        state: StateMethods;
+    }
+
+    //#region "ajax-methods"
+
+    interface AjaxMethods extends DataTable {
+        /**
+        * Reload the table data from the Ajax data source.
+        *
+        * @param callback Function which is executed when the data as been reloaded and the table fully redrawn.
+        * @param resetPaging Reset (default action or true) or hold the current paging position (false).
+        */
+        load(callback?: Function, resetPaging?: boolean): DataTable;
+    }
+
+    interface AjaxMethodModel {
+        /**
+        * Get the latest JSON data obtained from the last Ajax request DataTables made
+        */
+        json(): Object;
+
+        /**
+        * Get the data submitted by DataTables to the server in the last Ajax request
+        */
+        params(): Object;
+
+        /**
+        * Reload the table data from the Ajax data source.
+        *
+        * @param callback Function which is executed when the data as been reloaded and the table fully redrawn.
+        * @param resetPaging Reset (default action or true) or hold the current paging position (false).
+        */
+        reload(callback?: Function, resetPaging?: boolean): DataTable;
+
+        /**
+        * Reload the table data from the Ajax data source
+        */
+        url(): string;
+
+        /**
+        * Reload the table data from the Ajax data source
+        *
+        * @param url URL to set to be the Ajax data source for the table.
+        */
+        url(url: string): AjaxMethods;
+    }
+
+    //#endregion "ajax-methods"
+
+    //#region "order-methods"
+
+    interface OrderMethods {
+        /**
+        * Get the ordering applied to the table.
+        */
+        (): (string | number)[][];
+
+        /**
+        * Set the ordering applied to the table.
+        *
+        * @param order Order Model
+        */
+        (order?: (string | number)[]): DataTable;
+        (order?: (string | number)[][]): DataTable;
+        (order: (string | number)[], ...args: any[]): DataTable;
+
+        /**
+        * Add an ordering listener to an element, for a given column.
+        *
+        * @param node Selector
+        * @param column Column index
+        * @param callback Callback function
+        */
+        listener(node: string | Node | JQuery, column: number, callback: Function): DataTable;
+    }
+    //#endregion "order-methods"
+
+    //#region "page-methods"
+
+    interface PageMethods {
+        /**
+        * Get the current page of the table.
+        */
+        (): number;
+
+        /**
+        * Set the current page of the table.
+        *
+        * @param page Index or 'first', 'next', 'previous', 'last'
+        */
+        (page: number | string): DataTable;
+
+        /**
+        * Get paging information about the table
+        */
+        info(): PageMethodeModelInfoReturn;
+
+        /**
+        * Get the table's page length.
+        */
+        len(): number;
+
+        /**
+        * Set the table's page length.
+        *
+        * @param length Page length to set. use -1 to show all records.
+        */
+        len(length: number): DataTable;
+    }
+
+    interface PageMethodeModelInfoReturn {
+        page: number;
+        pages: number;
+        start: number;
+        end: number;
+        length: number;
+        recordsTotal: number;
+        recordsDisplay: number;
+    }
+
+    //#endregion "page-methods"
+
+    //#region "state-methods"
+
+    interface StateMethods {
+        /**
+        * Get the last saved state of the table
+        */
+        (): StateReturnModel;
+
+        /**
+        * Clear the saved state of the table.
+        */
+        clear(): DataTable;
+
+        /**
+        * Get the table state that was loaded during initialisation.
+        */
+        loaded(): StateReturnModel;
+
+        /**
+        * Trigger a state save.
+        */
+        save(): DataTable;
+    }
+
+    interface StateReturnModel {
+        time: number;
+        start: number;
+        length: number;
+        order: (string | number)[][];
+        search: SearchSettings;
+        columns: StateReturnModelColumns[];
+    }
+
+    interface StateReturnModelColumns {
+        search: SearchSettings;
+        visible: boolean;
+    }
+
+    //#endregion "state-methods"
+
+    //#endregion "core-methods"
+
+    //#region "util-methods"
+
+    interface UtilityMethods {
+        /**
+        * Concatenate two or more API instances together
+        *
+        * @param a API instance to concatenate to the initial instance.
+        * @param b Additional API instance(s) to concatenate to the initial instance.
+        */
+        concat(a: Object, ...b: Object[]): DataTable;
+
+        /**
+        * Iterate over the contents of the API result set.
+        *
+        * @param fn Callback function which is called for each item in the API instance result set. The callback is called with three parameters
+        */
+        each(fn: Function): DataTable;
+
+        /**
+        * Reduce an Api instance to a single context and result set.
+        *
+        * @param idx Index to select
+        */
+        eq(idx: number): DataTable;
+
+        /**
+        * Iterate over the result set of an API instance and test each item, creating a new instance from those items which pass.
+        *
+        * @param fn Callback function which is called for each item in the API instance result set. The callback is called with three parameters.
+        */
+        filter(fn: Function): DataTable;
+
+        /**
+        * Flatten a 2D array structured API instance to a 1D array structure.
+        */
+        flatten(): DataTable;
+
+        /**
+        * Find the first instance of a value in the API instance's result set.
+        *
+        * @param value Value to find in the instance's result set.
+        */
+        indexOf(value: any): number;
+
+        /**
+        * Join the elements in the result set into a string.
+        *
+        * @param separator The string that will be used to separate each element of the result set.
+        */
+        join(separator: string): string;
+
+        /**
+        * Find the last instance of a value in the API instance's result set.
+        *
+        * @param value Value to find in the instance's result set.
+        */
+        lastIndexOf(value: any): number;
+
+        /**
+        * Number of elements in an API instance's result set.
+        */
+        length: number;
+
+        /**
+        * Iterate over the result set of an API instance, creating a new API instance from the values returned by the callback.
+        *
+        * @param fn Callback function which is called for each item in the API instance result set. The callback is called with three parameters.
+        */
+        map(fn: Function): DataTable;
+
+        /**
+        * Iterate over the result set of an API instance, creating a new API instance from the values retrieved from the original elements.
+        *
+        * @param property Object property name to use from the element in the original result set for the new result set.
+        */
+        pluck(property: number | string): DataTable;
+
+        /**
+        * Remove the last item from an API instance's result set.
+        */
+        pop(): any;
+
+        /**
+        * Add one or more items to the end of an API instance's result set.
+        *
+        * @param value_1 Item to add to the API instance's result set.
+        */
+        push(value_1: any | any[], ...value_2: any[]): number;
+
+        /**
+        * Apply a callback function against and accumulator and each element in the Api's result set (left-to-right).
+        *
+        * @param fn Callback function which is called for each item in the API instance result set. The callback is called with four parameters.
+        * @param initialValue Value to use as the first argument of the first call to the fn callback.
+        */
+        reduce(fn: Function, initialValue?: any): any;
+
+        /**
+        * Apply a callback function against and accumulator and each element in the Api's result set (right-to-left).
+        *
+        * @param fn Callback function which is called for each item in the API instance result set. The callback is called with four parameters.
+        * @param initialValue Value to use as the first argument of the first call to the fn callback.
+        */
+        reduceRight(fn: Function, initialValue?: any): any;
+
+        /**
+        * Reverse the result set of the API instance and return the original array.
+        */
+        reverse(): DataTable;
+
+        /**
+        * Remove the first item from an API instance's result set.
+        */
+        shift(): any;
+
+        /**
+        * Sort the elements of the API instance's result set.
+        *
+        * @param fn This is a standard Javascript sort comparison function. It accepts two parameters.
+        */
+        sort(fn?: Function): DataTable;
+
+        /**
+        * Modify the contents of an Api instance's result set, adding or removing items from it as required.
+        *
+        * @param index Index at which to start modifying the Api instance's result set.
+        * @param howMany Number of elements to remove from the result set.
+        * @param value_1 Item to add to the result set at the index specified by the first parameter.
+        */
+        splice(index: number, howMany: number, value_1?: any | any[], ...value_2: any[]): any[];
+
+        /**
+        * Convert the API instance to a jQuery object, with the objects from the instance's result set in the jQuery result set.
+        */
+        to$(): JQuery;
+
+        /**
+        * Create a native Javascript array object from an API instance.
+        */
+        toArray(): any[];
+
+        /**
+        * Convert the API instance to a jQuery object, with the objects from the instance's result set in the jQuery result set.
+        */
+        toJQuery(): JQuery;
+
+        /**
+        * Create a new API instance containing only the unique items from a the elements in an instance's result set.
+        */
+        unique(): DataTable;
+
+        /**
+        * Add one or more items to the start of an API instance's result set.
+        *
+        * @param value_1 Item to add to the API instance's result set.
+        */
+        unshift(value_1: any | any[], ...value_2: any[]): number;
+    }
+
+    //#endregion "util-methods"
+
+    interface CommonSubMethods {
+        /**
+        * Get the DataTables cached data for the selected cell
+        *
+        * @param t Specify which cache the data should be read from. Can take one of two values: search or order
+        */
+        cache(t: string): DataTable;
+    }
+
+    //#region "cell-methods"
+
+    interface CommonCellMethods extends CommonSubMethods {
+        /**
+        * Invalidate the data held in DataTables for the selected cells
+        *
+        * @param source Data source to read the new data from.
+        */
+        invalidate(source?: string): DataTable;
+
+        /**
+        * Get data for the selected cell
+        *
+        * @param f Data type to get. This can be one of: 'display', 'filter', 'sort', 'type'
+        */
+        render(t: string): any;
+    }
+
+    interface CellMethods extends DataTableCore, CommonCellMethods {
+        /**
+        * Get data for the selected cell
+        */
+        data(): any;
+
+        /**
+        * Get data for the selected cell
+        *
+        * @param data Value to assign to the data for the cell
+        */
+        data(data: any): DataTable;
+
+        /**
+        * Get index information about the selected cell
+        */
+        index(): CellIndexReturn;
+
+        /**
+        * Get the DOM element for the selected cell
+        */
+        node(): Node;
+    }
+
+    interface CellIndexReturn {
+        row: number;
+        column: number;
+        columnVisible: number;
+    }
+
+    interface CellsMethods extends DataTableCore, CommonCellMethods {
+        /**
+        * Get data for the selected cells
+        */
+        data(): DataTable;
+
+        /**
+        * Get index information about the selected cells
+        */
+        indexes(): DataTable;
+
+        /**
+        * Get the DOM elements for the selected cells
+        */
+        nodes(): DataTable;
+    }
+    //#endregion "cell-methods"
+
+    //#region "column-methods"
+
+    interface CommonColumnMethod extends CommonSubMethods {
+        /**
+        * Get the footer th / td cell for the selected column.
+        */
+        footer(): any;
+
+        /**
+        * Get the header th / td cell for a column.
+        */
+        header(): Node;
+
+        /**
+        * Order the table, in the direction specified, by the column selected by the column()DT selector.
+        *
+        * @param direction Direction of sort to apply to the selected column - desc (descending) or asc (ascending).
+        */
+        order(direction: string): DataTable;
+
+        /**
+        * Get the visibility of the selected column.
+        */
+        visible(): boolean;
+
+        /**
+        * Set the visibility of the selected column.
+        *
+        * @param show Specify if the column should be visible (true) or not (false).
+        * @param redrawCalculations Indicate if DataTables should recalculate the column layout (true - default) or not (false). Typically this would be left as the default value, but it can be useful to disable when using the method in a loop - so the calculations are performed on every call as they can hamper performance.
+        */
+        visible(show: boolean, redrawCalculations?: boolean): DataTable;
+    }
+
+    interface ColumnMethodsModel {
+        /**
+        * Select the column found by a column selector
+        *
+        * @param cellSelector Cell selector.
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        (columnSelector: any, modifier?: ObjectSelectorModifier): ColumnMethods;
+
+        /**
+        * Convert from the input column index type to that required.
+        *
+        * @param t The type on conversion that should take place: 'fromVisible', 'toData', 'fromData', 'toVisible'
+        * @param index The index to be converted
+        */
+        index(t: string, index: number): number;
+    }
+
+    interface ColumnMethods extends DataTableCore, CommonColumnMethod {
+        /**
+        * Get the data for the cells in the selected column.
+        */
+        data(): DataTable;
+
+        /**
+        * Get the data source property for the selected column
+        */
+        dataSrc(): number | string | Function;
+
+        /**
+        * Get index information about the selected cell
+        *
+        * @param t Specify if you want to get the column data index (default) or the visible index (visible).
+        */
+        index(t?: string): DataTable;
+
+        /**
+        * Obtain the th / td nodes for the selected column
+        */
+        nodes(): DataTable[];
+    }
+
+    interface ColumnsMethodsModel {
+        /**
+        * Select all columns
+        *
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        (modifier?: ObjectSelectorModifier): ColumnsMethods;
+
+        /**
+        * Select columns found by a cell selector
+        *
+        * @param cellSelector Cell selector.
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        (columnSelector: any, modifier?: ObjectSelectorModifier): ColumnsMethods;
+
+        /**
+        * Recalculate the column widths for layout.
+        */
+        adjust(): DataTable;
+    }
+
+    interface ColumnsMethods extends DataTableCore, CommonColumnMethod {
+        /**
+        * Obtain the data for the columns from the selector
+        */
+        data(): DataTable;
+
+        /**
+        * Get the data source property for the selected columns.
+        */
+        dataSrc(): DataTable;
+
+        /**
+        * Get the column indexes of the selected columns.
+        *
+        * @param t Specify if you want to get the column data index (default) or the visible index (visible).
+        */
+        indexes(t?: string): DataTable;
+
+        /**
+        * Obtain the th / td nodes for the selected columns
+        */
+        nodes(): DataTable[][];
+    }
+    //#endregion "column-methods"
+
+    //#region "row-methods"
+
+    interface CommonRowMethod extends CommonSubMethods {
+        /**
+        * Obtain the th / td nodes for the selected column
+        *
+        * @param source Data source to read the new data from. Values: 'auto', 'data', 'dom'
+        */
+        invalidate(source?: string): DataTable;
+    }
+
+    interface RowChildMethodModel {
+        /**
+        * Get the child row(s) that have been set for a parent row
+        */
+        (): JQuery;
+
+        /**
+        * Get the child row(s) that have been set for a parent row
+        *
+        * @param showRemove This parameter can be given as true or false
+        */
+        (showRemove: boolean): RowChildMethods;
+
+        /**
+        * Set the data to show in the child row(s). Note that calling this method will replace any child rows which are already attached to the parent row.
+        *
+        * @param data The data to be shown in the child row can be given in multiple different ways.
+        * @param className Class name that is added to the td cell node(s) of the child row(s). As of 1.10.1 it is also added to the tr row node of the child row(s).
+        */
+        (data: (string | Node | JQuery) | (string | Node | JQuery)[], className?: string): RowChildMethods;
+
+        /**
+        * Hide the child row(s) of a parent row
+        */
+        hide(): DataTable;
+
+        /**
+        * Check if the child rows of a parent row are visible
+        */
+        isShown(): DataTable;
+
+        /**
+        * Remove child row(s) from display and release any allocated memory
+        */
+        remove(): DataTable;
+
+        /**
+        * Show the child row(s) of a parent row
+        */
+        show(): DataTable;
+    }
+
+    interface RowChildMethods extends DataTableCore {
+        /**
+        * Hide the child row(s) of a parent row
+        */
+        hide(): DataTable;
+
+        /**
+        * Remove child row(s) from display and release any allocated memory
+        */
+        remove(): DataTable;
+
+        /**
+        * Make newly defined child rows visible
+        */
+        show(): DataTable;
+    }
+
+    interface RowMethodsModel {
+        /**
+        * Select a row found by a row selector
+        *
+        * @param rowSelector Row selector.
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        (rowSelector: any, modifier?: ObjectSelectorModifier): RowMethods;
+
+        /**
+        * Add a new row to the table using the given data
+        *
+        * @param data Data to use for the new row. This may be an array, object or Javascript object instance, but must be in the same format as the other data in the table
+        */
+        add(data: any[]| Object): DataTable;
+    }
+
+    interface RowMethods extends DataTableCore, CommonRowMethod {
+        /**
+        * Order Methods / Object
+        */
+        child: RowChildMethodModel;
+
+        /**
+        * Get the data for the selected row
+        */
+        data(): any[]| Object;
+
+        /**
+        * Set the data for the selected row
+        *
+        * @param d Data to use for the row.
+        */
+        data(d: any[]| Object): DataTable;
+
+        /**
+        * Get the row index of the row column.
+        */
+        index(): number;
+
+        /**
+        * Obtain the tr node for the selected row
+        */
+        node(): Node;
+
+        /**
+        * Delete the selected row from the DataTable.
+        */
+        remove(): Node;
+    }
+
+    interface RowsMethodsModel {
+        /**
+        * Select all rows
+        *
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        (modifier?: ObjectSelectorModifier): RowsMethods;
+
+        /**
+        * Select rows found by a row selector
+        *
+        * @param cellSelector Row selector.
+        * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
+        */
+        (rowSelector: any, modifier?: ObjectSelectorModifier): RowsMethods;
+
+        /**
+        * Add new rows to the table using the data given
+        *
+        * @param data Array of data elements, with each one describing a new row to be added to the table
+        */
+        add(data: any[]): DataTable;
+    }
+
+    interface RowsMethods extends DataTableCore, CommonRowMethod {
+        /**
+        * Get the data for the rows from the selector
+        */
+        data(): DataTable;
+
+        /**
+        * Set the data for the selected row
+        *
+        * @param d Data to use for the row.
+        */
+        data(d: any[]| Object): DataTable;
+
+        /**
+        * Get the row indexes of the selected rows.
+        */
+        indexes(): DataTable;
+
+        /**
+        * Obtain the tr nodes for the selected rows
+        */
+        nodes(): DataTable;
+
+        /**
+        * Delete the selected rows from the DataTable.
+        */
+        remove(): DataTable;
+    }
+    //#endregion "row-methods"
+
+    //#region "table-methods"
+
+    interface TableMethods extends DataTableCore {
+        /**
+        * Get the tfoot node for the table in the API's context
+        */
+        footer(): Node;
+
+        /**
+        * Get the thead node for the table in the API's context
+        */
+        header(): Node;
+
+        /**
+        * Get the tbody node for the table in the API's context
+        */
+        body(): Node;
+
+        /**
+        * Get the div container node for the table in the API's context
+        */
+        container(): Node;
+
+        /**
+        * Get the table node for the table in the API's context
+        */
+        node(): Node;
+    }
+
+    interface TablesMethods extends DataTableCore {
+        /**
+        * Get the tfoot nodes for the tables in the API's context
+        */
+        footer(): DataTable;
+
+        /**
+        * Get the thead nodes for the tables in the API's context
+        */
+        header(): DataTable;
+
+        /**
+        * Get the tbody nodes for the tables in the API's context
+        */
+        body(): DataTable;
+
+        /**
+        * Get the div container nodes for the tables in the API's context
+        */
+        containers(): DataTable;
+
+        /**
+        * Get the table nodes for the tables in the API's context
+        */
+        nodes(): DataTable;
+    }
+    //#endregion "table-methods"
+
+    //#endregion "Namespaces"
+
+    //#region "Static-Methods"
+
+    export interface StaticFunctions {
+        /**
+        * Check is a table node is a DataTable or not
+        *
+        * @param table Selector string for table
+        */
+        isDataTable(table: string): boolean;
+
+        /**
+        * Get all DataTables on the page
+        *
+        * @param visible Get only visible tables
+        */
+        tables(visible?: boolean): DataTables.DataTable[];
+
+        /**
+        * Version number compatibility check function
+        *
+        * @param version Version string
+        */
+        versionCheck(version: string): boolean;
+
+        /**
+        * Utils
+        */
+        util: StaticUtilFunctions;
+
+        /**
+        * Check is a table node is a DataTable or not
+        *
+        * @param table Selector string for table
+        */
+        Api(selector: string | Node | Node[]| JQuery): DataTables.DataTable;
+    }
+
+    export interface StaticUtilFunctions {
+        /**
+        * Escape special characters in a regular expression string. Since: 1.10.4
+        *
+        * @param str String to escape
+        */
+        escapeRegex(str: string): string;
+
+        /**
+        * Throttle the calls to a method to reduce call frequency. Since: 1.10.3
+        *
+        * @param fn Function
+        * @param period ms
+        */
+        throttle(fn: Function, period?: number): Function;
+    }
+
+    //#endregion "Static-Methods"
+
+    //#region "Settings"
+
+    export interface Settings {
+
+        //#region "Features"
+
+        /**
+        * Feature control DataTables' smart column width handling. Since: 1.10
+        */
+        autoWidth?: boolean;
+
+        /**
+        * Feature control deferred rendering for additional speed of initialisation. Since: 1.10
+        */
+        deferRender?: boolean;
+
+        /**
+        * Feature control table information display field. Since: 1.10
+        */
+        info?: boolean;
+
+        /**
+        * Use markup and classes for the table to be themed by jQuery UI ThemeRoller. Since: 1.10
+        */
+        jQueryUI?: boolean;
+
+        /**
+        * Feature control the end user's ability to change the paging display length of the table. Since: 1.10
+        */
+        lengthChange?: boolean;
+
+        /**
+        * Feature control ordering (sorting) abilities in DataTables. Since: 1.10
+        */
+        ordering?: boolean;
+
+        /**
+        * Enable or disable table pagination. Since: 1.10
+        */
+        paging?: boolean;
+
+        /**
+        * Feature control the processing indicator. Since: 1.10
+        */
+        processing?: boolean;
+
+        /**
+        * Horizontal scrolling. Since: 1.10
+        */
+        scrollX?: boolean;
+
+        /**
+        * Vertical scrolling. Since: 1.10 Exp: "200px"
+        */
+        scrollY?: string;
+
+        /**
+        * Feature control search (filtering) abilities Since: 1.10
+        */
+        searching?: boolean;
+
+        /**
+        * Feature control DataTables' server-side processing mode. Since: 1.10
+        */
+        serverSide?: boolean;
+
+        /**
+        * State saving - restore table state on page reload. Since: 1.10
+        */
+        stateSave?: boolean;
+
+        //#endregion "Features"
+
+        //#region "Data"
+
+        /**
+        * Load data for the table's content from an Ajax source. Since: 1.10
+        */
+        ajax?: string | AjaxSettings | FunctionAjax;
+
+        /**
+        * Data to use as the display data for the table. Since: 1.10
+        */
+        data?: Object;
+
+        //#endregion "Data"
+
+        //#region "Options"
+
+        /**
+        * Data to use as the display data for the table. Since: 1.10
+        */
+        columns?: ColumnSettings[];
+
+        /**
+        * Assign a column definition to one or more columns.. Since: 1.10
+        */
+        columnDefs?: ColumnDefsSettings[];
+
+        /**
+        * Delay the loading of server-side data until second draw
+        */
+        deferLoading?: number | number[];
+
+        /**
+        * Destroy any existing table matching the selector and replace with the new options. Since: 1.10
+        */
+        destroy?: boolean;
+
+        /**
+        * Initial paging start point. Since: 1.10
+        */
+        displayStart?: number;
+
+        /**
+        * Define the table control elements to appear on the page and in what order. Since: 1.10
+        */
+        dom?: string;
+
+        /**
+        * Change the options in the page length select list. Since: 1.10
+        */
+        lengthMenu?: (number | string)[]| (number | string)[][];
+
+        /**
+        * Control which cell the order event handler will be applied to in a column. Since: 1.10
+        */
+        orderCellsTop?: boolean;
+
+        /**
+        * Highlight the columns being ordered in the table's body. Since: 1.10
+        */
+        orderClasses?: boolean;
+
+        /**
+        * Initial order (sort) to apply to the table. Since: 1.10
+        */
+        order?: (string | number)[]| (string | number)[][];
+
+        /**
+        * Ordering to always be applied to the table. Since: 1.10
+        */
+        orderFixed?: (string | number)[]| (string | number)[][]| Object;
+
+        /**
+        * Multiple column ordering ability control. Since: 1.10
+        */
+        orderMulti?: boolean;
+
+        /**
+        * Change the initial page length (number of rows per page). Since: 1.10
+        */
+        pageLength?: number;
+
+        /**
+        * Pagination button display options. Basic Types: simple, simple_numbers, full, full_numbers
+        */
+        pagingType?: string;
+
+        /**
+        * Retrieve an existing DataTables instance. Since: 1.10
+        */
+        retrieve?: boolean
+
+        /**
+        * Display component renderer types. Since: 1.10
+        */
+        renderer?: string | RendererSettings;
+
+        /**
+        * Allow the table to reduce in height when a limited number of rows are shown. Since: 1.10
+        */
+        scrollCollapse?: boolean;
+
+        /**
+        * Set an initial filter in DataTables and / or filtering options. Since: 1.10
+        */
+        search?: SearchSettings;
+
+        /**
+        * Define an initial search for individual columns. Since: 1.10
+        */
+        searchCols?: SearchSettings[];
+
+        /**
+        * Set a throttle frequency for searching. Since: 1.10
+        */
+        searchDelay?: number;
+
+        /**
+        * Saved state validity duration. Since: 1.10
+        */
+        stateDuration?: number;
+
+        /**
+        * Set the zebra stripe class names for the rows in the table. Since: 1.10
+        */
+        stripeClasses?: string[];
+
+        /**
+        * Tab index control for keyboard navigation. Since: 1.10
+        */
+        tabIndex?: number;
+
+        //#endregion "Options"
+
+        //#region "Callbacks"
+
+        /**
+        * Callback for whenever a TR element is created for the table's body. Since: 1.10
+        */
+        createdRow?: FunctionCreateRow;
+
+        /**
+        * Function that is called every time DataTables performs a draw. Since: 1.10
+        */
+        drawCallback?: FunctionDrawCallback;
+
+        /**
+        * Footer display callback function. Since: 1.10
+        */
+        footerCallback?: FunctionFooterCallback;
+
+        /**
+        * Number formatting callback function. Since: 1.10
+        */
+        formatNumber?: FunctionFormatNumber;
+
+        /**
+        * Header display callback function. Since: 1.10
+        */
+        headerCallback?: FunctionHeaderCallback;
+
+        /**
+        * Table summary information display callback. Since: 1.10
+        */
+        infoCallback?: FunctionInfoCallback;
+
+        /**
+        * Initialisation complete callback. Since: 1.10
+        */
+        initComplete?: FunctionInitComplete;
+
+        /**
+        * Pre-draw callback. Since: 1.10
+        */
+        preDrawCallback?: FunctionPreDrawCallback;
+
+        /**
+        * Row draw callback.. Since: 1.10
+        */
+        rowCallback?: FunctionRowCallback;
+
+        /**
+        * Callback that defines where and how a saved state should be loaded. Since: 1.10
+        */
+        stateLoadCallback?: FunctionStateLoadCallback;
+
+        /**
+        * State loaded callback. Since: 1.10
+        */
+        stateLoaded?: FunctionStateLoaded;
+
+        /**
+        * State loaded - data manipulation callback. Since: 1.10
+        */
+        stateLoadParams?: FunctionStateLoadParams;
+
+        /**
+        * Callback that defines how the table state is stored and where. Since: 1.10
+        */
+        stateSaveCallback?: FunctionStateSaveCallback;
+
+        /**
+        * State save - data manipulation callback. Since: 1.10
+        */
+        stateSaveParams?: FunctionStateSaveParams;
+
+        //#endregion "Callbacks"
+
+        //#region "Language"
+
+        language?: LanguageSettings;
+
+        //#endregion "Language"
+    }
+
+    //#region "ajax-settings"
+
+    export interface AjaxDataRequest {
+        draw: number;
+        start: number;
+        length: number;
+        data: any;
+        order: AjaxDataRequestOrder[];
+        columns: AjaxDataRequestColumn[];
+        search: AjaxDataRequestSearch;
+    }
+
+    export interface AjaxDataRequestSearch {
+        value: string;
+        regex: boolean;
+    }
+
+    export interface AjaxDataRequestOrder {
+        column: number;
+        dir: string;
+    }
+
+    export interface AjaxDataRequestColumn {
+        data: string | number;
+        name: string;
+        searchable: boolean;
+        orderable: boolean;
+        search: AjaxDataRequestSearch;
+    }
+
+    export interface AjaxData {
+        draw: number;
+        recordsTotal: number;
+        recordsFiltered: number;
+        data: any;
+        error?: string;
+    }
+
+    interface AjaxSettings extends JQueryAjaxSettings {
+        /**
+        * Add or modify data submitted to the server upon an Ajax request. Since: 1.10
+        */
+        data?: Object | FunctionAjaxData;
+
+        /**
+        * Data property or manipulation method for table data. Since: 1.10
+        */
+        dataSrc?: string | Function;
+    }
+
+    interface FunctionAjax {
+        (data: Object, callback: Function, settings: SettingsLegacy): void;
+    }
+
+    interface FunctionAjaxData {
+        (data: Object): string | Object;
+    }
+
+    //#endregion "ajax-settings"
+
+    //#region "colunm-settings"
+
+    export interface ColumnSettings {
+        /**
+        * Cell type to be created for a column. th/td Since: 1.10
+        */
+        cellType?: string;
+
+        /**
+        * Class to assign to each cell in the column. Since: 1.10
+        */
+        className?: string;
+
+        /**
+        * Add padding to the text content used when calculating the optimal with for a table. Since: 1.10
+        */
+        contentPadding?: string;
+
+        /**
+        * Cell created callback to allow DOM manipulation. Since: 1.10
+        */
+        createdCell?: FunctionColumnCreatedCell;
+
+        /**
+        * Class to assign to each cell in the column. Since: 1.10
+        */
+        data?: number | string | ObjectColumnData | FunctionColumnData;
+
+        /**
+        * Set default, static, content for a column. Since: 1.10
+        */
+        defaultContent?: string;
+
+        /**
+        * Set a descriptive name for a column. Since: 1.10
+        */
+        name?: string;
+
+        /**
+        * Enable or disable ordering on this column. Since: 1.10
+        */
+        orderable?: boolean;
+
+        /**
+        * Define multiple column ordering as the default order for a column. Since: 1.10
+        */
+        orderData?: number | number[];
+
+        /**
+        * Live DOM sorting type assignment. Since: 1.10
+        */
+        orderDataType?: string;
+
+        /**
+        * Order direction application sequence. Since: 1.10
+        */
+        orderSequence?: string[];
+
+        /**
+        * Render (process) the data for use in the table. Since: 1.10
+        */
+        render?: number | string | ObjectColumnRender | FunctionColumnRender;
+
+        /**
+        * Enable or disable filtering on the data in this column. Since: 1.10
+        */
+        searchable?: boolean;
+
+        /**
+        * Set the column title. Since: 1.10
+        */
+        title?: string;
+
+        /**
+        * Set the column type - used for filtering and sorting string processing. Since: 1.10
+        */
+        type?: string;
+
+        /**
+        * Enable or disable the display of this column. Since: 1.10
+        */
+        visible?: boolean;
+
+        /**
+        * Column width assignment. Since: 1.10
+        */
+        width?: string;
+    }
+
+    interface ColumnDefsSettings extends ColumnSettings {
+        targets: string | number | (number | string)[]
+    }
+
+    interface FunctionColumnCreatedCell {
+        (cell: Node, cellData: any, rowData: any, row: number, col: number): void;
+    }
+
+    interface FunctionColumnData {
+        (row: any, t: string, s: any, meta: CellMetaSettings): void;
+    }
+
+    interface ObjectColumnData {
+        _: string;
+        filter?: string;
+        display?: string;
+        type?: string;
+        sort?: string;
+    }
+
+    interface ObjectColumnRender extends ObjectColumnData {
+    }
+
+    interface FunctionColumnRender {
+        (data: any, t: string, row: any, meta: CellMetaSettings): void;
+    }
+
+    interface CellMetaSettings {
+        row: number;
+        col: number;
+        settings: DataTables.Settings;
+    }
+
+    //#endregion "colunm-settings"
+
+    //#region "other-settings"
+
+    export interface RendererSettings {
+        header?: string;
+        pageButton?: string;
+    }
+
+    export interface SearchSettings {
+        /**
+        * Control case-sensitive filtering option. Since: 1.10
+        */
+        caseInsensitive?: boolean;
+
+        /**
+        * Enable / disable escaping of regular expression characters in the search term. Since: 1.10
+        */
+        regex?: boolean;
+
+        /**
+        * Enable / disable DataTables' smart filtering. Since: 1.10
+        */
+        smart?: boolean;
+
+        /**
+        * Set an initial filtering condition on the table. Since: 1.10
+        */
+        search?: string;
+    }
+
+    //#endregion "other-settings"
+
+    //#region "callback-functions"
+
+    interface FunctionCreateRow {
+        (row: Node, data: any[]| Object, dataIndex: number): void;
+    }
+
+    interface FunctionDrawCallback {
+        (settings: SettingsLegacy): void;
+    }
+
+    interface FunctionFooterCallback {
+        (tfoot: Node, data: any[], start: number, end: number, display: any[]): void;
+    }
+
+    interface FunctionFormatNumber {
+        (formatNumber: number): void;
+    }
+
+    interface FunctionHeaderCallback {
+        (thead: Node, data: any[], start: number, end: number, display: any[]): void;
+    }
+
+    interface FunctionInfoCallback {
+        (settings: SettingsLegacy, start: number, end: number, mnax: number, total: number, pre: string): void;
+    }
+
+    interface FunctionInitComplete {
+        (settings: SettingsLegacy, json: Object): void;
+    }
+
+    interface FunctionPreDrawCallback {
+        (settings: SettingsLegacy): void;
+    }
+
+    interface FunctionRowCallback {
+        (row: Node, data: any[]| Object): void;
+    }
+
+    interface FunctionStateLoadCallback {
+        (settings: SettingsLegacy): void;
+    }
+
+    interface FunctionStateLoaded {
+        (settings: SettingsLegacy, data: Object): void;
+    }
+
+    interface FunctionStateLoadParams {
+        (settings: SettingsLegacy, data: Object): void;
+    }
+
+    interface FunctionStateSaveCallback {
+        (settings: SettingsLegacy, data: Object): void;
+    }
+
+    interface FunctionStateSaveParams {
+        (settings: SettingsLegacy, data: Object): void;
+    }
+
+    //#endregion "callback-functions"
+
+    //#region "language-settings"
+
+	// these are all optional
+    interface LanguageSettings {
+        emptyTable?: string;
+        info?: string;
+        infoEmpty?: string;
+        infoFiltered?: string;
+        infoPostFix?: string;
+        thousands?: string;
+        lengthMenu?: string;
+        loadingRecords?: string;
+        processing?: string;
+        search?: string;
+        zeroRecords?: string;
+        paginate?: LanguagePaginateSettings;
+        aria?: LanguageAriaSettings;
+    }
+
+    interface LanguagePaginateSettings {
+        first: string;
+        last: string;
+        next: string;
+        previous: string;
+    }
+
+    interface LanguageAriaSettings {
+        sortAscending: string;
+        sortDescending: string;
+    }
+
+    //#endregion "language-settings"
+
+    //#endregion "Settings"
+
+    //#region "SettingsLegacy"
+
+    interface ArrayStringNode {
+        [index: string]: Node;
+    }
+
+    export interface SettingsLegacy {
+        ajax?: any;
+        oApi?: any;
+        oFeatures?: FeaturesLegacy;
+        oScroll?: ScrollingLegacy;
+        oLanguage?: LanguageLegacy; // | { fnInfoCallback: FunctionInfoCallback; };
+        oBrowser?: { bScrollOversize: boolean; };
+        aanFeatures?: ArrayStringNode[][];
+        aoData?: RowLegacy[];
+        aiDisplay?: number[];
+        aiDisplayMaster?: number[];
+        aoColumns?: ColumnLegacy[];
+        aoHeader?: any[];
+        aoFooter?: any[];
+        asDataSearch?: string[];
+        oPreviousSearch?: any;
+        aoPreSearchCols?: any[];
+        aaSorting?: any[][];
+        aaSortingFixed?: any[][];
+        asStripeClasses?: string[];
+        asDestroyStripes?: string[];
+        sDestroyWidth?: number;
+        aoRowCallback?: FunctionRowCallback[];
+        aoHeaderCallback?: FunctionHeaderCallback[];
+        aoFooterCallback?: FunctionFooterCallback[];
+        aoDrawCallback?: FunctionDrawCallback[];
+        aoRowCreatedCallback?: FunctionCreateRow[];
+        aoPreDrawCallback?: FunctionPreDrawCallback[];
+        aoInitComplete?: FunctionInitComplete[];
+        aoStateSaveParams?: FunctionStateSaveParams[];
+        aoStateLoadParams?: FunctionStateLoadParams[];
+        aoStateLoaded?: FunctionStateLoaded[];
+        sTableId?: string;
+        nTable?: Node;
+        nTHead?: Node;
+        nTFoot?: Node;
+        nTBody?: Node;
+        nTableWrapper?: Node;
+        bDeferLoading?: boolean;
+        bInitialized?: boolean;
+        aoOpenRows?: any[];
+        sDom?: string;
+        sPaginationType?: string;
+        iCookieDuration?: number;
+        sCookiePrefix?: string;
+        fnCookieCallback?: CookieCallbackLegacy;
+        aoStateSave?: FunctionStateSaveCallback[];
+        aoStateLoad?: FunctionStateLoadCallback[];
+        oLoadedState?: any;
+        sAjaxSource?: string;
+        sAjaxDataProp?: string;
+        bAjaxDataGet?: boolean;
+        jqXHR?: any;
+        fnServerData?: any;
+        aoServerParams?: any[];
+        sServerMethod?: string;
+        fnFormatNumber?: FunctionFormatNumber;
+        aLengthMenu?: any[];
+        iDraw?: number;
+        bDrawing?: boolean;
+        iDrawError?: number;
+        _iDisplayLength?: number;
+        _iDisplayStart?: number;
+        _iDisplayEnd?: number;
+        _iRecordsTotal?: number;
+        _iRecordsDisplay?: number;
+        bJUI?: boolean;
+        oClasses?: any;
+        bFiltered?: boolean;
+        bSorted?: boolean;
+        bSortCellsTop?: boolean;
+        oInit?: any;
+        aoDestroyCallback?: any[];
+        fnRecordsTotal?: () => number;
+        fnRecordsDisplay?: () => number;
+        fnDisplayEnd?: () => number;
+        oInstance?: any;
+        sInstance?: string;
+        iTabIndex?: number;
+        nScrollHead?: Node;
+        nScrollFoot?: Node;
+        sScrollY?: string;
+        bScrollCollapse?: boolean;
+    }
+
+    export interface FeaturesLegacy {
+        bAutoWidth?: boolean;
+        bDeferRender?: boolean;
+        bFilter?: boolean;
+        bInfo?: boolean;
+        bLengthChange?: boolean;
+        bPaginate?: boolean;
+        bProcessing?: boolean;
+        bServerSide?: boolean;
+        bSort?: boolean;
+        bSortClasses?: boolean;
+        bStateSave?: boolean;
+    }
+
+    export interface ScrollingLegacy {
+        bAutoCss: boolean;
+        bCollapse: boolean;
+        bInfinite: boolean;
+        iBarWidth: number;
+        iLoadGap: number;
+        sX: string;
+        sY: string;
+    }
+
+    export interface RowLegacy {
+        nTr: Node;
+        _aData: any;
+        _aSortData: any[];
+        _anHidden: Node[];
+        _sRowStripe: string;
+    }
+
+    export interface ColumnLegacy {
+        aDataSort: any;
+        asSorting: string[];
+        bSearchable: boolean;
+        bSortable: boolean;
+        bVisible: boolean;
+        _bAutoType: boolean;
+        fnCreatedCell: FunctionColumnCreatedCell;
+        fnGetData: (data: any, specific: string) => any;
+        fnSetData: (data: any, value: any) => void;
+        mData: any;
+        mRender: any;
+        nTh: Node;
+        nIf: Node;
+        sClass: string;
+        sContentPadding: string;
+        sDefaultContent: string;
+        sName: string;
+        sSortDataType: string;
+        sSortingClass: string;
+        sSortingClassJUI: string;
+        sTitle: string;
+        sType: string;
+        sWidth: string;
+        sWidthOrig: string;
+    }
+
+    export interface CookieCallbackLegacy {
+        (name: string, data: any, expires: string, path: string, cookie: string): void;
+    }
+
+    export interface LanguageLegacy {
+        oAria?: LanguageAriaLegacy;
+        oPaginate?: LanguagePaginateLegacy;
+        sEmptyTable?: string;
+        sInfo?: string;
+        sInfoEmpty?: string;
+        sInfoFiltered?: string;
+        sInfoPostFix?: string;
+        sInfoThousands?: string;
+        sLengthMenu?: string;
+        sLoadingRecords?: string;
+        sProcessing?: string;
+        sSearch?: string;
+        sUrl?: string;
+        sZeroRecords?: string;
+    }
+
+    export interface LanguageAriaLegacy {
+        sSortAscending?: string;
+        sSortDescending?: string;
+    }
+
+    export interface LanguagePaginateLegacy {
+        sFirst?: string;
+        sLast?: string;
+        sNext?: string;
+        sPrevious?: string;
+    }
+    //#endregion "SettingsLegacy"
+
+}

--- a/typings/jquery/jquery.d.ts
+++ b/typings/jquery/jquery.d.ts
@@ -1,0 +1,3190 @@
+// Type definitions for jQuery 1.10.x / 2.0.x
+// Project: http://jquery.com/
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Christian Hoffmeister <https://github.com/choffmeister>, Steve Fenton <https://github.com/Steve-Fenton>, Diullei Gomes <https://github.com/Diullei>, Tass Iliopoulos <https://github.com/tasoili>, Jason Swearingen <https://github.com/jasons-novaleaf>, Sean Hill <https://github.com/seanski>, Guus Goossens <https://github.com/Guuz>, Kelly Summerlin <https://github.com/ksummerlin>, Basarat Ali Syed <https://github.com/basarat>, Nicholas Wolverson <https://github.com/nwolverson>, Derek Cicerone <https://github.com/derekcicerone>, Andrew Gaspar <https://github.com/AndrewGaspar>, James Harrison Fisher <https://github.com/jameshfisher>, Seikichi Kondo <https://github.com/seikichi>, Benjamin Jackman <https://github.com/benjaminjackman>, Poul Sorensen <https://github.com/s093294>, Josh Strobl <https://github.com/JoshStrobl>, John Reilly <https://github.com/johnnyreilly/>, Dick van den Brink <https://github.com/DickvdBrink>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/* *****************************************************************************
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions
+and limitations under the License.
+***************************************************************************** */
+
+
+/**
+ * Interface for the AJAX setting that will configure the AJAX request
+ */
+interface JQueryAjaxSettings {
+    /**
+     * The content type sent in the request header that tells the server what kind of response it will accept in return. If the accepts setting needs modification, it is recommended to do so once in the $.ajaxSetup() method.
+     */
+    accepts?: any;
+    /**
+     * By default, all requests are sent asynchronously (i.e. this is set to true by default). If you need synchronous requests, set this option to false. Cross-domain requests and dataType: "jsonp" requests do not support synchronous operation. Note that synchronous requests may temporarily lock the browser, disabling any actions while the request is active. As of jQuery 1.8, the use of async: false with jqXHR ($.Deferred) is deprecated; you must use the success/error/complete callback options instead of the corresponding methods of the jqXHR object such as jqXHR.done() or the deprecated jqXHR.success().
+     */
+    async?: boolean;
+    /**
+     * A pre-request callback function that can be used to modify the jqXHR (in jQuery 1.4.x, XMLHTTPRequest) object before it is sent. Use this to set custom headers, etc. The jqXHR and settings objects are passed as arguments. This is an Ajax Event. Returning false in the beforeSend function will cancel the request. As of jQuery 1.5, the beforeSend option will be called regardless of the type of request.
+     */
+    beforeSend? (jqXHR: JQueryXHR, settings: JQueryAjaxSettings): any;
+    /**
+     * If set to false, it will force requested pages not to be cached by the browser. Note: Setting cache to false will only work correctly with HEAD and GET requests. It works by appending "_={timestamp}" to the GET parameters. The parameter is not needed for other types of requests, except in IE8 when a POST is made to a URL that has already been requested by a GET.
+     */
+    cache?: boolean;
+    /**
+     * A function to be called when the request finishes (after success and error callbacks are executed). The function gets passed two arguments: The jqXHR (in jQuery 1.4.x, XMLHTTPRequest) object and a string categorizing the status of the request ("success", "notmodified", "error", "timeout", "abort", or "parsererror"). As of jQuery 1.5, the complete setting can accept an array of functions. Each function will be called in turn. This is an Ajax Event.
+     */
+    complete? (jqXHR: JQueryXHR, textStatus: string): any;
+    /**
+     * An object of string/regular-expression pairs that determine how jQuery will parse the response, given its content type. (version added: 1.5)
+     */
+    contents?: { [key: string]: any; };
+    //According to jQuery.ajax source code, ajax's option actually allows contentType to set to "false"
+    // https://github.com/borisyankov/DefinitelyTyped/issues/742
+    /**
+     * When sending data to the server, use this content type. Default is "application/x-www-form-urlencoded; charset=UTF-8", which is fine for most cases. If you explicitly pass in a content-type to $.ajax(), then it is always sent to the server (even if no data is sent). The W3C XMLHttpRequest specification dictates that the charset is always UTF-8; specifying another charset will not force the browser to change the encoding.
+     */
+    contentType?: any;
+    /**
+     * This object will be made the context of all Ajax-related callbacks. By default, the context is an object that represents the ajax settings used in the call ($.ajaxSettings merged with the settings passed to $.ajax).
+     */
+    context?: any;
+    /**
+     * An object containing dataType-to-dataType converters. Each converter's value is a function that returns the transformed value of the response. (version added: 1.5)
+     */
+    converters?: { [key: string]: any; };
+    /**
+     * If you wish to force a crossDomain request (such as JSONP) on the same domain, set the value of crossDomain to true. This allows, for example, server-side redirection to another domain. (version added: 1.5)
+     */
+    crossDomain?: boolean;
+    /**
+     * Data to be sent to the server. It is converted to a query string, if not already a string. It's appended to the url for GET-requests. See processData option to prevent this automatic processing. Object must be Key/Value pairs. If value is an Array, jQuery serializes multiple values with same key based on the value of the traditional setting (described below).
+     */
+    data?: any;
+    /**
+     * A function to be used to handle the raw response data of XMLHttpRequest.This is a pre-filtering function to sanitize the response. You should return the sanitized data. The function accepts two arguments: The raw data returned from the server and the 'dataType' parameter.
+     */
+    dataFilter? (data: any, ty: any): any;
+    /**
+     * The type of data that you're expecting back from the server. If none is specified, jQuery will try to infer it based on the MIME type of the response (an XML MIME type will yield XML, in 1.4 JSON will yield a JavaScript object, in 1.4 script will execute the script, and anything else will be returned as a string). 
+     */
+    dataType?: string;
+    /**
+     * A function to be called if the request fails. The function receives three arguments: The jqXHR (in jQuery 1.4.x, XMLHttpRequest) object, a string describing the type of error that occurred and an optional exception object, if one occurred. Possible values for the second argument (besides null) are "timeout", "error", "abort", and "parsererror". When an HTTP error occurs, errorThrown receives the textual portion of the HTTP status, such as "Not Found" or "Internal Server Error." As of jQuery 1.5, the error setting can accept an array of functions. Each function will be called in turn. Note: This handler is not called for cross-domain script and cross-domain JSONP requests. This is an Ajax Event.
+     */
+    error? (jqXHR: JQueryXHR, textStatus: string, errorThrown: string): any;
+    /**
+     * Whether to trigger global Ajax event handlers for this request. The default is true. Set to false to prevent the global handlers like ajaxStart or ajaxStop from being triggered. This can be used to control various Ajax Events.
+     */
+    global?: boolean;
+    /**
+     * An object of additional header key/value pairs to send along with requests using the XMLHttpRequest transport. The header X-Requested-With: XMLHttpRequest is always added, but its default XMLHttpRequest value can be changed here. Values in the headers setting can also be overwritten from within the beforeSend function. (version added: 1.5)
+     */
+    headers?: { [key: string]: any; };
+    /**
+     * Allow the request to be successful only if the response has changed since the last request. This is done by checking the Last-Modified header. Default value is false, ignoring the header. In jQuery 1.4 this technique also checks the 'etag' specified by the server to catch unmodified data.
+     */
+    ifModified?: boolean;
+    /**
+     * Allow the current environment to be recognized as "local," (e.g. the filesystem), even if jQuery does not recognize it as such by default. The following protocols are currently recognized as local: file, *-extension, and widget. If the isLocal setting needs modification, it is recommended to do so once in the $.ajaxSetup() method. (version added: 1.5.1)
+     */
+    isLocal?: boolean;
+    /**
+     * Override the callback function name in a jsonp request. This value will be used instead of 'callback' in the 'callback=?' part of the query string in the url. So {jsonp:'onJSONPLoad'} would result in 'onJSONPLoad=?' passed to the server. As of jQuery 1.5, setting the jsonp option to false prevents jQuery from adding the "?callback" string to the URL or attempting to use "=?" for transformation. In this case, you should also explicitly set the jsonpCallback setting. For example, { jsonp: false, jsonpCallback: "callbackName" }
+     */
+    jsonp?: any;
+    /**
+     * Specify the callback function name for a JSONP request. This value will be used instead of the random name automatically generated by jQuery. It is preferable to let jQuery generate a unique name as it'll make it easier to manage the requests and provide callbacks and error handling. You may want to specify the callback when you want to enable better browser caching of GET requests. As of jQuery 1.5, you can also use a function for this setting, in which case the value of jsonpCallback is set to the return value of that function.
+     */
+    jsonpCallback?: any;
+    /**
+     * The HTTP method to use for the request (e.g. "POST", "GET", "PUT"). (version added: 1.9.0)
+     */
+    method?: string;
+    /**
+     * A mime type to override the XHR mime type. (version added: 1.5.1)
+     */
+    mimeType?: string;
+    /**
+     * A password to be used with XMLHttpRequest in response to an HTTP access authentication request.
+     */
+    password?: string;
+    /**
+     * By default, data passed in to the data option as an object (technically, anything other than a string) will be processed and transformed into a query string, fitting to the default content-type "application/x-www-form-urlencoded". If you want to send a DOMDocument, or other non-processed data, set this option to false.
+     */
+    processData?: boolean;
+    /**
+     * Only applies when the "script" transport is used (e.g., cross-domain requests with "jsonp" or "script" dataType and "GET" type). Sets the charset attribute on the script tag used in the request. Used when the character set on the local page is not the same as the one on the remote script.
+     */
+    scriptCharset?: string;
+    /**
+     * An object of numeric HTTP codes and functions to be called when the response has the corresponding code. f the request is successful, the status code functions take the same parameters as the success callback; if it results in an error (including 3xx redirect), they take the same parameters as the error callback. (version added: 1.5)
+     */
+    statusCode?: { [key: string]: any; };
+    /**
+     * A function to be called if the request succeeds. The function gets passed three arguments: The data returned from the server, formatted according to the dataType parameter; a string describing the status; and the jqXHR (in jQuery 1.4.x, XMLHttpRequest) object. As of jQuery 1.5, the success setting can accept an array of functions. Each function will be called in turn. This is an Ajax Event.
+     */
+    success? (data: any, textStatus: string, jqXHR: JQueryXHR): any;
+    /**
+     * Set a timeout (in milliseconds) for the request. This will override any global timeout set with $.ajaxSetup(). The timeout period starts at the point the $.ajax call is made; if several other requests are in progress and the browser has no connections available, it is possible for a request to time out before it can be sent. In jQuery 1.4.x and below, the XMLHttpRequest object will be in an invalid state if the request times out; accessing any object members may throw an exception. In Firefox 3.0+ only, script and JSONP requests cannot be cancelled by a timeout; the script will run even if it arrives after the timeout period.
+     */
+    timeout?: number;
+    /**
+     * Set this to true if you wish to use the traditional style of param serialization.
+     */
+    traditional?: boolean;
+    /**
+     * The type of request to make ("POST" or "GET"), default is "GET". Note: Other HTTP request methods, such as PUT and DELETE, can also be used here, but they are not supported by all browsers.
+     */
+    type?: string;
+    /**
+     * A string containing the URL to which the request is sent.
+     */
+    url?: string;
+    /**
+     * A username to be used with XMLHttpRequest in response to an HTTP access authentication request.
+     */
+    username?: string;
+    /**
+     * Callback for creating the XMLHttpRequest object. Defaults to the ActiveXObject when available (IE), the XMLHttpRequest otherwise. Override to provide your own implementation for XMLHttpRequest or enhancements to the factory.
+     */
+    xhr?: any;
+    /**
+     * An object of fieldName-fieldValue pairs to set on the native XHR object. For example, you can use it to set withCredentials to true for cross-domain requests if needed. In jQuery 1.5, the withCredentials property was not propagated to the native XHR and thus CORS requests requiring it would ignore this flag. For this reason, we recommend using jQuery 1.5.1+ should you require the use of it. (version added: 1.5.1)
+     */
+    xhrFields?: { [key: string]: any; };
+}
+
+/**
+ * Interface for the jqXHR object
+ */
+interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
+    /**
+     * The .overrideMimeType() method may be used in the beforeSend() callback function, for example, to modify the response content-type header. As of jQuery 1.5.1, the jqXHR object also contains the overrideMimeType() method (it was available in jQuery 1.4.x, as well, but was temporarily removed in jQuery 1.5). 
+     */
+    overrideMimeType(mimeType: string): any;
+    /**
+     * Cancel the request. 
+     *
+     * @param statusText A string passed as the textStatus parameter for the done callback. Default value: "canceled"
+     */
+    abort(statusText?: string): void;
+    /**
+     * Incorporates the functionality of the .done() and .fail() methods, allowing (as of jQuery 1.8) the underlying Promise to be manipulated. Refer to deferred.then() for implementation details.
+     */
+    then(doneCallback: (data: any, textStatus: string, jqXHR: JQueryXHR) => void, failCallback?: (jqXHR: JQueryXHR, textStatus: string, errorThrown: any) => void): JQueryPromise<any>;
+    /**
+     * Property containing the parsed response if the response Content-Type is json
+     */
+    responseJSON?: any;
+    /**
+     * A function to be called if the request fails.
+     */
+    error(xhr: JQueryXHR, textStatus: string, errorThrown: string): void;
+}
+
+/**
+ * Interface for the JQuery callback
+ */
+interface JQueryCallback {
+    /**
+     * Add a callback or a collection of callbacks to a callback list.
+     * 
+     * @param callbacks A function, or array of functions, that are to be added to the callback list.
+     */
+    add(callbacks: Function): JQueryCallback;
+    /**
+     * Add a callback or a collection of callbacks to a callback list.
+     * 
+     * @param callbacks A function, or array of functions, that are to be added to the callback list.
+     */
+    add(callbacks: Function[]): JQueryCallback;
+
+    /**
+     * Disable a callback list from doing anything more.
+     */
+    disable(): JQueryCallback;
+
+    /**
+     * Determine if the callbacks list has been disabled.
+     */
+    disabled(): boolean;
+
+    /**
+     * Remove all of the callbacks from a list.
+     */
+    empty(): JQueryCallback;
+
+    /**
+     * Call all of the callbacks with the given arguments
+     * 
+     * @param arguments The argument or list of arguments to pass back to the callback list.
+     */
+    fire(...arguments: any[]): JQueryCallback;
+
+    /**
+     * Determine if the callbacks have already been called at least once.
+     */
+    fired(): boolean;
+
+    /**
+     * Call all callbacks in a list with the given context and arguments.
+     * 
+     * @param context A reference to the context in which the callbacks in the list should be fired.
+     * @param arguments An argument, or array of arguments, to pass to the callbacks in the list.
+     */
+    fireWith(context?: any, args?: any[]): JQueryCallback;
+
+    /**
+     * Determine whether a supplied callback is in a list
+     * 
+     * @param callback The callback to search for.
+     */
+    has(callback: Function): boolean;
+
+    /**
+     * Lock a callback list in its current state.
+     */
+    lock(): JQueryCallback;
+
+    /**
+     * Determine if the callbacks list has been locked.
+     */
+    locked(): boolean;
+
+    /**
+     * Remove a callback or a collection of callbacks from a callback list.
+     * 
+     * @param callbacks A function, or array of functions, that are to be removed from the callback list.
+     */
+    remove(callbacks: Function): JQueryCallback;
+    /**
+     * Remove a callback or a collection of callbacks from a callback list.
+     * 
+     * @param callbacks A function, or array of functions, that are to be removed from the callback list.
+     */
+    remove(callbacks: Function[]): JQueryCallback;
+}
+
+/**
+ * Allows jQuery Promises to interop with non-jQuery promises
+ */
+interface JQueryGenericPromise<T> {
+    /**
+     * Add handlers to be called when the Deferred object is resolved, rejected, or still in progress.
+     * 
+     * @param doneFilter A function that is called when the Deferred is resolved.
+     * @param failFilter An optional function that is called when the Deferred is rejected.
+     */
+    then<U>(doneFilter: (value?: T, ...values: any[]) => U|JQueryPromise<U>, failFilter?: (...reasons: any[]) => any, progressFilter?: (...progression: any[]) => any): JQueryPromise<U>;
+
+    /**
+     * Add handlers to be called when the Deferred object is resolved, rejected, or still in progress.
+     * 
+     * @param doneFilter A function that is called when the Deferred is resolved.
+     * @param failFilter An optional function that is called when the Deferred is rejected.
+     */
+    then(doneFilter: (value?: T, ...values: any[]) => void, failFilter?: (...reasons: any[]) => any, progressFilter?: (...progression: any[]) => any): JQueryPromise<void>;
+}
+
+/**
+ * Interface for the JQuery promise/deferred callbacks
+ */
+interface JQueryPromiseCallback<T> {
+    (value?: T, ...args: any[]): void;
+}
+
+interface JQueryPromiseOperator<T, U> {
+    (callback1: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...callbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<U>;
+}
+
+/**
+ * Interface for the JQuery promise, part of callbacks
+ */
+interface JQueryPromise<T> extends JQueryGenericPromise<T> {
+    /**
+     * Determine the current state of a Deferred object.
+     */
+    state(): string;
+    /**
+     * Add handlers to be called when the Deferred object is either resolved or rejected.
+     * 
+     * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
+     * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
+     */
+    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    /**
+     * Add handlers to be called when the Deferred object is resolved.
+     * 
+     * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
+     * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
+     */
+    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryPromise<T>;
+    /**
+     * Add handlers to be called when the Deferred object is rejected.
+     * 
+     * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
+     * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
+     */
+    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    /**
+     * Add handlers to be called when the Deferred object generates progress notifications.
+     * 
+     * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
+     */
+    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+
+    // Deprecated - given no typings
+    pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise<any>;
+}
+
+/**
+ * Interface for the JQuery deferred, part of callbacks
+ */
+interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
+    /**
+     * Determine the current state of a Deferred object.
+     */
+    state(): string;
+    /**
+     * Add handlers to be called when the Deferred object is either resolved or rejected.
+     * 
+     * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
+     * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
+     */
+    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
+    /**
+     * Add handlers to be called when the Deferred object is resolved.
+     * 
+     * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
+     * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
+     */
+    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryDeferred<T>;
+    /**
+     * Add handlers to be called when the Deferred object is rejected.
+     * 
+     * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
+     * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
+     */
+    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
+    /**
+     * Add handlers to be called when the Deferred object generates progress notifications.
+     * 
+     * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
+     */
+    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
+
+    /**
+     * Call the progressCallbacks on a Deferred object with the given args.
+     * 
+     * @param args Optional arguments that are passed to the progressCallbacks.
+     */
+    notify(value?: any, ...args: any[]): JQueryDeferred<T>;
+
+    /**
+     * Call the progressCallbacks on a Deferred object with the given context and args.
+     * 
+     * @param context Context passed to the progressCallbacks as the this object.
+     * @param args Optional arguments that are passed to the progressCallbacks.
+     */
+    notifyWith(context: any, value?: any[]): JQueryDeferred<T>;
+
+    /**
+     * Reject a Deferred object and call any failCallbacks with the given args.
+     * 
+     * @param args Optional arguments that are passed to the failCallbacks.
+     */
+    reject(value?: any, ...args: any[]): JQueryDeferred<T>;
+    /**
+     * Reject a Deferred object and call any failCallbacks with the given context and args.
+     * 
+     * @param context Context passed to the failCallbacks as the this object.
+     * @param args An optional array of arguments that are passed to the failCallbacks.
+     */
+    rejectWith(context: any, value?: any[]): JQueryDeferred<T>;
+
+    /**
+     * Resolve a Deferred object and call any doneCallbacks with the given args.
+     * 
+     * @param value First argument passed to doneCallbacks.
+     * @param args Optional subsequent arguments that are passed to the doneCallbacks.
+     */
+    resolve(value?: T, ...args: any[]): JQueryDeferred<T>;
+
+    /**
+     * Resolve a Deferred object and call any doneCallbacks with the given context and args.
+     * 
+     * @param context Context passed to the doneCallbacks as the this object.
+     * @param args An optional array of arguments that are passed to the doneCallbacks.
+     */
+    resolveWith(context: any, value?: T[]): JQueryDeferred<T>;
+
+    /**
+     * Return a Deferred's Promise object.
+     * 
+     * @param target Object onto which the promise methods have to be attached
+     */
+    promise(target?: any): JQueryPromise<T>;
+
+    // Deprecated - given no typings
+    pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise<any>;
+}
+
+/**
+ * Interface of the JQuery extension of the W3C event object
+ */
+interface BaseJQueryEventObject extends Event {
+    data: any;
+    delegateTarget: Element;
+    isDefaultPrevented(): boolean;
+    isImmediatePropagationStopped(): boolean;
+    isPropagationStopped(): boolean;
+    namespace: string;
+    originalEvent: Event;
+    preventDefault(): any;
+    relatedTarget: Element;
+    result: any;
+    stopImmediatePropagation(): void;
+    stopPropagation(): void;
+    target: Element;
+    pageX: number;
+    pageY: number;
+    which: number;
+    metaKey: boolean;
+}
+
+interface JQueryInputEventObject extends BaseJQueryEventObject {
+    altKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
+}
+
+interface JQueryMouseEventObject extends JQueryInputEventObject {
+    button: number;
+    clientX: number;
+    clientY: number;
+    offsetX: number;
+    offsetY: number;
+    pageX: number;
+    pageY: number;
+    screenX: number;
+    screenY: number;
+}
+
+interface JQueryKeyEventObject extends JQueryInputEventObject {
+    char: any;
+    charCode: number;
+    key: any;
+    keyCode: number;
+}
+
+interface JQueryEventObject extends BaseJQueryEventObject, JQueryInputEventObject, JQueryMouseEventObject, JQueryKeyEventObject{
+}
+
+/*
+    Collection of properties of the current browser
+*/
+
+interface JQuerySupport {
+    ajax?: boolean;
+    boxModel?: boolean;
+    changeBubbles?: boolean;
+    checkClone?: boolean;
+    checkOn?: boolean;
+    cors?: boolean;
+    cssFloat?: boolean;
+    hrefNormalized?: boolean;
+    htmlSerialize?: boolean;
+    leadingWhitespace?: boolean;
+    noCloneChecked?: boolean;
+    noCloneEvent?: boolean;
+    opacity?: boolean;
+    optDisabled?: boolean;
+    optSelected?: boolean;
+    scriptEval? (): boolean;
+    style?: boolean;
+    submitBubbles?: boolean;
+    tbody?: boolean;
+}
+
+interface JQueryParam {
+    /**
+     * Create a serialized representation of an array or object, suitable for use in a URL query string or Ajax request.
+     * 
+     * @param obj An array or object to serialize.
+     */
+    (obj: any): string;
+
+    /**
+     * Create a serialized representation of an array or object, suitable for use in a URL query string or Ajax request.
+     * 
+     * @param obj An array or object to serialize.
+     * @param traditional A Boolean indicating whether to perform a traditional "shallow" serialization.
+     */
+    (obj: any, traditional: boolean): string;
+}
+
+/**
+ * The interface used to construct jQuery events (with $.Event). It is
+ * defined separately instead of inline in JQueryStatic to allow
+ * overriding the construction function with specific strings
+ * returning specific event objects.
+ */
+interface JQueryEventConstructor {
+    (name: string, eventProperties?: any): JQueryEventObject;
+    new (name: string, eventProperties?: any): JQueryEventObject;
+}
+
+/**
+ * The interface used to specify coordinates.
+ */
+interface JQueryCoordinates {
+    left: number;
+    top: number;
+}
+
+/**
+ * Elements in the array returned by serializeArray()
+ */
+interface JQuerySerializeArrayElement {
+    name: string;
+    value: string;
+}
+
+interface JQueryAnimationOptions { 
+    /**
+     * A string or number determining how long the animation will run.
+     */
+    duration?: any; 
+    /**
+     * A string indicating which easing function to use for the transition.
+     */
+    easing?: string; 
+    /**
+     * A function to call once the animation is complete.
+     */
+    complete?: Function; 
+    /**
+     * A function to be called for each animated property of each animated element. This function provides an opportunity to modify the Tween object to change the value of the property before it is set.
+     */
+    step?: (now: number, tween: any) => any; 
+    /**
+     * A function to be called after each step of the animation, only once per animated element regardless of the number of animated properties. (version added: 1.8)
+     */
+    progress?: (animation: JQueryPromise<any>, progress: number, remainingMs: number) => any; 
+    /**
+     * A function to call when the animation begins. (version added: 1.8)
+     */
+    start?: (animation: JQueryPromise<any>) => any; 
+    /**
+     * A function to be called when the animation completes (its Promise object is resolved). (version added: 1.8)
+     */
+    done?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any; 
+    /**
+     * A function to be called when the animation fails to complete (its Promise object is rejected). (version added: 1.8)
+     */
+    fail?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any; 
+    /**
+     * A function to be called when the animation completes or stops without completing (its Promise object is either resolved or rejected). (version added: 1.8)
+     */
+    always?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any; 
+    /**
+     * A Boolean indicating whether to place the animation in the effects queue. If false, the animation will begin immediately. As of jQuery 1.7, the queue option can also accept a string, in which case the animation is added to the queue represented by that string. When a custom queue name is used the animation does not automatically start; you must call .dequeue("queuename") to start it.
+     */
+    queue?: any; 
+    /**
+     * A map of one or more of the CSS properties defined by the properties argument and their corresponding easing functions. (version added: 1.4)
+     */
+    specialEasing?: Object;
+}
+
+/**
+ * Static members of jQuery (those on $ and jQuery themselves)
+ */
+interface JQueryStatic {
+
+    /**
+     * Perform an asynchronous HTTP (Ajax) request.
+     *
+     * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can be set for any option with $.ajaxSetup().
+     */
+    ajax(settings: JQueryAjaxSettings): JQueryXHR;
+    /**
+     * Perform an asynchronous HTTP (Ajax) request.
+     *
+     * @param url A string containing the URL to which the request is sent.
+     * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can be set for any option with $.ajaxSetup().
+     */
+    ajax(url: string, settings?: JQueryAjaxSettings): JQueryXHR;
+
+    /**
+     * Handle custom Ajax options or modify existing options before each request is sent and before they are processed by $.ajax().
+     *
+     * @param dataTypes An optional string containing one or more space-separated dataTypes
+     * @param handler A handler to set default values for future Ajax requests.
+     */
+    ajaxPrefilter(dataTypes: string, handler: (opts: any, originalOpts: JQueryAjaxSettings, jqXHR: JQueryXHR) => any): void;
+    /**
+     * Handle custom Ajax options or modify existing options before each request is sent and before they are processed by $.ajax().
+     *
+     * @param handler A handler to set default values for future Ajax requests.
+     */
+    ajaxPrefilter(handler: (opts: any, originalOpts: JQueryAjaxSettings, jqXHR: JQueryXHR) => any): void;
+
+    ajaxSettings: JQueryAjaxSettings;
+
+     /**
+      * Set default values for future Ajax requests. Its use is not recommended.
+      *
+      * @param options A set of key/value pairs that configure the default Ajax request. All options are optional.
+      */
+    ajaxSetup(options: JQueryAjaxSettings): void;
+
+    /**
+     * Load data from the server using a HTTP GET request.
+     *
+     * @param url A string containing the URL to which the request is sent.
+     * @param success A callback function that is executed if the request succeeds.
+     * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, or html).
+     */
+    get(url: string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
+    /**
+     * Load data from the server using a HTTP GET request.
+     *
+     * @param url A string containing the URL to which the request is sent.
+     * @param data A plain object or string that is sent to the server with the request.
+     * @param success A callback function that is executed if the request succeeds.
+     * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, or html).
+     */
+    get(url: string, data?: Object|string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
+    /**
+     * Load JSON-encoded data from the server using a GET HTTP request.
+     *
+     * @param url A string containing the URL to which the request is sent.
+     * @param success A callback function that is executed if the request succeeds.
+     */
+    getJSON(url: string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any): JQueryXHR;
+    /**
+     * Load JSON-encoded data from the server using a GET HTTP request.
+     *
+     * @param url A string containing the URL to which the request is sent.
+     * @param data A plain object or string that is sent to the server with the request.
+     * @param success A callback function that is executed if the request succeeds.
+     */
+    getJSON(url: string, data?: Object|string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any): JQueryXHR;
+    /**
+     * Load a JavaScript file from the server using a GET HTTP request, then execute it.
+     *
+     * @param url A string containing the URL to which the request is sent.
+     * @param success A callback function that is executed if the request succeeds.
+     */
+    getScript(url: string, success?: (script: string, textStatus: string, jqXHR: JQueryXHR) => any): JQueryXHR;
+
+    /**
+     * Create a serialized representation of an array or object, suitable for use in a URL query string or Ajax request.
+     */
+    param: JQueryParam;
+
+    /**
+     * Load data from the server using a HTTP POST request.
+     *
+     * @param url A string containing the URL to which the request is sent.
+     * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but can be null in that case.
+     * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
+     */
+    post(url: string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
+    /**
+     * Load data from the server using a HTTP POST request.
+     *
+     * @param url A string containing the URL to which the request is sent.
+     * @param data A plain object or string that is sent to the server with the request.
+     * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but can be null in that case.
+     * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
+     */
+    post(url: string, data?: Object|string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
+
+    /**
+     * A multi-purpose callbacks list object that provides a powerful way to manage callback lists.
+     *
+     * @param flags An optional list of space-separated flags that change how the callback list behaves.
+     */
+    Callbacks(flags?: string): JQueryCallback;
+
+    /**
+     * Holds or releases the execution of jQuery's ready event.
+     *
+     * @param hold Indicates whether the ready hold is being requested or released
+     */
+    holdReady(hold: boolean): void;
+
+    /**
+     * Accepts a string containing a CSS selector which is then used to match a set of elements.
+     *
+     * @param selector A string containing a selector expression
+     * @param context A DOM Element, Document, or jQuery to use as context
+     */
+    (selector: string, context?: Element|JQuery): JQuery;
+
+    /**
+     * Accepts a string containing a CSS selector which is then used to match a set of elements.
+     *
+     * @param element A DOM element to wrap in a jQuery object.
+     */
+    (element: Element): JQuery;
+
+    /**
+     * Accepts a string containing a CSS selector which is then used to match a set of elements.
+     *
+     * @param elementArray An array containing a set of DOM elements to wrap in a jQuery object.
+     */
+    (elementArray: Element[]): JQuery;
+
+    /**
+     * Binds a function to be executed when the DOM has finished loading.
+     *
+     * @param callback A function to execute after the DOM is ready.
+     */
+    (callback: (jQueryAlias?: JQueryStatic) => any): JQuery;
+
+    /**
+     * Accepts a string containing a CSS selector which is then used to match a set of elements.
+     *
+     * @param object A plain object to wrap in a jQuery object.
+     */
+    (object: {}): JQuery;
+
+    /**
+     * Accepts a string containing a CSS selector which is then used to match a set of elements.
+     *
+     * @param object An existing jQuery object to clone.
+     */
+    (object: JQuery): JQuery;
+
+    /**
+     * Specify a function to execute when the DOM is fully loaded.
+     */
+    (): JQuery;
+
+    /**
+     * Creates DOM elements on the fly from the provided string of raw HTML.
+     *
+     * @param html A string of HTML to create on the fly. Note that this parses HTML, not XML.
+     * @param ownerDocument A document in which the new elements will be created.
+     */
+    (html: string, ownerDocument?: Document): JQuery;
+
+    /**
+     * Creates DOM elements on the fly from the provided string of raw HTML.
+     *
+     * @param html A string defining a single, standalone, HTML element (e.g. <div/> or <div></div>).
+     * @param attributes An object of attributes, events, and methods to call on the newly-created element.
+     */
+    (html: string, attributes: Object): JQuery;
+
+    /**
+     * Relinquish jQuery's control of the $ variable.
+     *
+     * @param removeAll A Boolean indicating whether to remove all jQuery variables from the global scope (including jQuery itself).
+     */
+    noConflict(removeAll?: boolean): Object;
+
+    /**
+     * Provides a way to execute callback functions based on one or more objects, usually Deferred objects that represent asynchronous events.
+     *
+     * @param deferreds One or more Deferred objects, or plain JavaScript objects.
+     */
+    when<T>(...deferreds: Array<T|JQueryPromise<T>/* as JQueryDeferred<T> */>): JQueryPromise<T>;
+
+    /**
+     * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize CSS property naming, or create custom properties.
+     */
+    cssHooks: { [key: string]: any; };
+    cssNumber: any;
+
+    /**
+     * Store arbitrary data associated with the specified element. Returns the value that was set.
+     *
+     * @param element The DOM element to associate with the data.
+     * @param key A string naming the piece of data to set.
+     * @param value The new data value.
+     */
+    data<T>(element: Element, key: string, value: T): T;
+    /**
+     * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or the full data store for the element.
+     *
+     * @param element The DOM element to associate with the data.
+     * @param key A string naming the piece of data to set.
+     */
+    data(element: Element, key: string): any;
+    /**
+     * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or the full data store for the element.
+     *
+     * @param element The DOM element to associate with the data.
+     */
+    data(element: Element): any;
+
+    /**
+     * Execute the next function on the queue for the matched element.
+     *
+     * @param element A DOM element from which to remove and execute a queued function.
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     */
+    dequeue(element: Element, queueName?: string): void;
+
+    /**
+     * Determine whether an element has any jQuery data associated with it.
+     *
+     * @param element A DOM element to be checked for data.
+     */
+    hasData(element: Element): boolean;
+
+    /**
+     * Show the queue of functions to be executed on the matched element.
+     *
+     * @param element A DOM element to inspect for an attached queue.
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     */
+    queue(element: Element, queueName?: string): any[];
+    /**
+     * Manipulate the queue of functions to be executed on the matched element.
+     *
+     * @param element A DOM element where the array of queued functions is attached.
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @param newQueue An array of functions to replace the current queue contents.
+     */
+    queue(element: Element, queueName: string, newQueue: Function[]): JQuery;
+    /**
+     * Manipulate the queue of functions to be executed on the matched element.
+     *
+     * @param element A DOM element on which to add a queued function.
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @param callback The new function to add to the queue.
+     */
+    queue(element: Element, queueName: string, callback: Function): JQuery;
+
+    /**
+     * Remove a previously-stored piece of data.
+     *
+     * @param element A DOM element from which to remove data.
+     * @param name A string naming the piece of data to remove.
+     */
+    removeData(element: Element, name?: string): JQuery;
+
+    /**
+     * A constructor function that returns a chainable utility object with methods to register multiple callbacks into callback queues, invoke callback queues, and relay the success or failure state of any synchronous or asynchronous function.
+     *
+     * @param beforeStart A function that is called just before the constructor returns.
+     */
+    Deferred<T>(beforeStart?: (deferred: JQueryDeferred<T>) => any): JQueryDeferred<T>;
+
+    /**
+     * Effects
+     */
+    fx: {
+        tick: () => void;
+        /**
+         * The rate (in milliseconds) at which animations fire.
+         */
+        interval: number;
+        stop: () => void;
+        speeds: { slow: number; fast: number; };
+        /**
+         * Globally disable all animations.
+         */
+        off: boolean;
+        step: any;
+    };
+
+    /**
+     * Takes a function and returns a new one that will always have a particular context.
+     *
+     * @param fnction The function whose context will be changed.
+     * @param context The object to which the context (this) of the function should be set.
+     * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
+     */
+    proxy(fnction: (...args: any[]) => any, context: Object, ...additionalArguments: any[]): any;
+    /**
+     * Takes a function and returns a new one that will always have a particular context.
+     *
+     * @param context The object to which the context (this) of the function should be set.
+     * @param name The name of the function whose context will be changed (should be a property of the context object).
+     * @param additionalArguments Any number of arguments to be passed to the function named in the name argument.
+     */
+    proxy(context: Object, name: string, ...additionalArguments: any[]): any;
+
+    Event: JQueryEventConstructor;
+
+    /**
+     * Takes a string and throws an exception containing it.
+     *
+     * @param message The message to send out.
+     */
+    error(message: any): JQuery;
+
+    expr: any;
+    fn: any;  //TODO: Decide how we want to type this
+
+    isReady: boolean;
+
+    // Properties
+    support: JQuerySupport;
+
+    /**
+     * Check to see if a DOM element is a descendant of another DOM element.
+     * 
+     * @param container The DOM element that may contain the other element.
+     * @param contained The DOM element that may be contained by (a descendant of) the other element.
+     */
+    contains(container: Element, contained: Element): boolean;
+
+    /**
+     * A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. Arrays and array-like objects with a length property (such as a function's arguments object) are iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.
+     * 
+     * @param collection The object or array to iterate over.
+     * @param callback The function that will be executed on every object.
+     */
+    each<T>(
+        collection: T[],
+        callback: (indexInArray: number, valueOfElement: T) => any
+        ): any;
+
+    /**
+     * A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. Arrays and array-like objects with a length property (such as a function's arguments object) are iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.
+     * 
+     * @param collection The object or array to iterate over.
+     * @param callback The function that will be executed on every object.
+     */
+    each(
+        collection: any,
+        callback: (indexInArray: any, valueOfElement: any) => any
+        ): any;
+
+    /**
+     * Merge the contents of two or more objects together into the first object.
+     *
+     * @param target An object that will receive the new properties if additional objects are passed in or that will extend the jQuery namespace if it is the sole argument.
+     * @param object1 An object containing additional properties to merge in.
+     * @param objectN Additional objects containing properties to merge in.
+     */
+    extend(target: any, object1?: any, ...objectN: any[]): any;
+    /**
+     * Merge the contents of two or more objects together into the first object.
+     *
+     * @param deep If true, the merge becomes recursive (aka. deep copy).
+     * @param target The object to extend. It will receive the new properties.
+     * @param object1 An object containing additional properties to merge in.
+     * @param objectN Additional objects containing properties to merge in.
+     */
+    extend(deep: boolean, target: any, object1?: any, ...objectN: any[]): any;
+
+    /**
+     * Execute some JavaScript code globally.
+     *
+     * @param code The JavaScript code to execute.
+     */
+    globalEval(code: string): any;
+
+    /**
+     * Finds the elements of an array which satisfy a filter function. The original array is not affected.
+     *
+     * @param array The array to search through.
+     * @param func The function to process each item against. The first argument to the function is the item, and the second argument is the index. The function should return a Boolean value.  this will be the global window object.
+     * @param invert If "invert" is false, or not provided, then the function returns an array consisting of all elements for which "callback" returns true. If "invert" is true, then the function returns an array consisting of all elements for which "callback" returns false.
+     */
+    grep<T>(array: T[], func: (elementOfArray: T, indexInArray: number) => boolean, invert?: boolean): T[];
+
+    /**
+     * Search for a specified value within an array and return its index (or -1 if not found).
+     *
+     * @param value The value to search for.
+     * @param array An array through which to search.
+     * @param fromIndex he index of the array at which to begin the search. The default is 0, which will search the whole array.
+     */
+    inArray<T>(value: T, array: T[], fromIndex?: number): number;
+
+    /**
+     * Determine whether the argument is an array.
+     *
+     * @param obj Object to test whether or not it is an array.
+     */
+    isArray(obj: any): boolean;
+    /**
+     * Check to see if an object is empty (contains no enumerable properties).
+     *
+     * @param obj The object that will be checked to see if it's empty.
+     */
+    isEmptyObject(obj: any): boolean;
+    /**
+     * Determine if the argument passed is a Javascript function object.
+     *
+     * @param obj Object to test whether or not it is a function.
+     */
+    isFunction(obj: any): boolean;
+    /**
+     * Determines whether its argument is a number.
+     *
+     * @param obj The value to be tested.
+     */
+    isNumeric(value: any): boolean;
+    /**
+     * Check to see if an object is a plain object (created using "{}" or "new Object").
+     *
+     * @param obj The object that will be checked to see if it's a plain object.
+     */
+    isPlainObject(obj: any): boolean;
+    /**
+     * Determine whether the argument is a window.
+     *
+     * @param obj Object to test whether or not it is a window.
+     */
+    isWindow(obj: any): boolean;
+    /**
+     * Check to see if a DOM node is within an XML document (or is an XML document).
+     *
+     * @param node he DOM node that will be checked to see if it's in an XML document.
+     */
+    isXMLDoc(node: Node): boolean;
+
+    /**
+     * Convert an array-like object into a true JavaScript array.
+     * 
+     * @param obj Any object to turn into a native Array.
+     */
+    makeArray(obj: any): any[];
+
+    /**
+     * Translate all items in an array or object to new array of items.
+     * 
+     * @param array The Array to translate.
+     * @param callback The function to process each item against. The first argument to the function is the array item, the second argument is the index in array The function can return any value. Within the function, this refers to the global (window) object.
+     */
+    map<T, U>(array: T[], callback: (elementOfArray: T, indexInArray: number) => U): U[];
+    /**
+     * Translate all items in an array or object to new array of items.
+     * 
+     * @param arrayOrObject The Array or Object to translate.
+     * @param callback The function to process each item against. The first argument to the function is the value; the second argument is the index or key of the array or object property. The function can return any value to add to the array. A returned array will be flattened into the resulting array. Within the function, this refers to the global (window) object.
+     */
+    map(arrayOrObject: any, callback: (value: any, indexOrKey: any) => any): any;
+
+    /**
+     * Merge the contents of two arrays together into the first array.
+     * 
+     * @param first The first array to merge, the elements of second added.
+     * @param second The second array to merge into the first, unaltered.
+     */
+    merge<T>(first: T[], second: T[]): T[];
+
+    /**
+     * An empty function.
+     */
+    noop(): any;
+
+    /**
+     * Return a number representing the current time.
+     */
+    now(): number;
+
+    /**
+     * Takes a well-formed JSON string and returns the resulting JavaScript object.
+     * 
+     * @param json The JSON string to parse.
+     */
+    parseJSON(json: string): any;
+
+    /**
+     * Parses a string into an XML document.
+     *
+     * @param data a well-formed XML string to be parsed
+     */
+    parseXML(data: string): XMLDocument;
+
+    /**
+     * Remove the whitespace from the beginning and end of a string.
+     * 
+     * @param str Remove the whitespace from the beginning and end of a string.
+     */
+    trim(str: string): string;
+
+    /**
+     * Determine the internal JavaScript [[Class]] of an object.
+     * 
+     * @param obj Object to get the internal JavaScript [[Class]] of.
+     */
+    type(obj: any): string;
+
+    /**
+     * Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.
+     * 
+     * @param array The Array of DOM elements.
+     */
+    unique(array: Element[]): Element[];
+
+    /**
+     * Parses a string into an array of DOM nodes.
+     *
+     * @param data HTML string to be parsed
+     * @param context DOM element to serve as the context in which the HTML fragment will be created
+     * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
+     */
+    parseHTML(data: string, context?: HTMLElement, keepScripts?: boolean): any[];
+
+    /**
+     * Parses a string into an array of DOM nodes.
+     *
+     * @param data HTML string to be parsed
+     * @param context DOM element to serve as the context in which the HTML fragment will be created
+     * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
+     */
+    parseHTML(data: string, context?: Document, keepScripts?: boolean): any[];
+}
+
+/**
+ * The jQuery instance members
+ */
+interface JQuery {
+    /**
+     * Register a handler to be called when Ajax requests complete. This is an AjaxEvent.
+     *
+     * @param handler The function to be invoked.
+     */
+    ajaxComplete(handler: (event: JQueryEventObject, XMLHttpRequest: XMLHttpRequest, ajaxOptions: any) => any): JQuery;
+    /**
+     * Register a handler to be called when Ajax requests complete with an error. This is an Ajax Event.
+     *
+     * @param handler The function to be invoked.
+     */
+    ajaxError(handler: (event: JQueryEventObject, jqXHR: JQueryXHR, ajaxSettings: JQueryAjaxSettings, thrownError: any) => any): JQuery;
+    /**
+     * Attach a function to be executed before an Ajax request is sent. This is an Ajax Event.
+     *
+     * @param handler The function to be invoked.
+     */
+    ajaxSend(handler: (event: JQueryEventObject, jqXHR: JQueryXHR, ajaxOptions: JQueryAjaxSettings) => any): JQuery;
+    /**
+     * Register a handler to be called when the first Ajax request begins. This is an Ajax Event.
+     *
+     * @param handler The function to be invoked.
+     */
+    ajaxStart(handler: () => any): JQuery;
+    /**
+     * Register a handler to be called when all Ajax requests have completed. This is an Ajax Event.
+     *
+     * @param handler The function to be invoked.
+     */
+    ajaxStop(handler: () => any): JQuery;
+    /**
+     * Attach a function to be executed whenever an Ajax request completes successfully. This is an Ajax Event.
+     *
+     * @param handler The function to be invoked.
+     */
+    ajaxSuccess(handler: (event: JQueryEventObject, XMLHttpRequest: XMLHttpRequest, ajaxOptions: JQueryAjaxSettings) => any): JQuery;
+
+    /**
+     * Load data from the server and place the returned HTML into the matched element.
+     *
+     * @param url A string containing the URL to which the request is sent.
+     * @param data A plain object or string that is sent to the server with the request.
+     * @param complete A callback function that is executed when the request completes.
+     */
+    load(url: string, data?: string|Object, complete?: (responseText: string, textStatus: string, XMLHttpRequest: XMLHttpRequest) => any): JQuery;
+
+    /**
+     * Encode a set of form elements as a string for submission.
+     */
+    serialize(): string;
+    /**
+     * Encode a set of form elements as an array of names and values.
+     */
+    serializeArray(): JQuerySerializeArrayElement[];
+
+    /**
+     * Adds the specified class(es) to each of the set of matched elements.
+     *
+     * @param className One or more space-separated classes to be added to the class attribute of each matched element.
+     */
+    addClass(className: string): JQuery;
+    /**
+     * Adds the specified class(es) to each of the set of matched elements.
+     *
+     * @param function A function returning one or more space-separated class names to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, this refers to the current element in the set.
+     */
+    addClass(func: (index: number, className: string) => string): JQuery;
+
+    /**
+     * Add the previous set of elements on the stack to the current set, optionally filtered by a selector.
+     */
+    addBack(selector?: string): JQuery;
+
+    /**
+     * Get the value of an attribute for the first element in the set of matched elements.
+     *
+     * @param attributeName The name of the attribute to get.
+     */
+    attr(attributeName: string): string;
+    /**
+     * Set one or more attributes for the set of matched elements.
+     *
+     * @param attributeName The name of the attribute to set.
+     * @param value A value to set for the attribute.
+     */
+    attr(attributeName: string, value: string|number): JQuery;
+    /**
+     * Set one or more attributes for the set of matched elements.
+     *
+     * @param attributeName The name of the attribute to set.
+     * @param func A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old attribute value as arguments.
+     */
+    attr(attributeName: string, func: (index: number, attr: string) => string|number): JQuery;
+    /**
+     * Set one or more attributes for the set of matched elements.
+     *
+     * @param attributes An object of attribute-value pairs to set.
+     */
+    attr(attributes: Object): JQuery;
+    
+    /**
+     * Determine whether any of the matched elements are assigned the given class.
+     *
+     * @param className The class name to search for.
+     */
+    hasClass(className: string): boolean;
+
+    /**
+     * Get the HTML contents of the first element in the set of matched elements.
+     */
+    html(): string;
+    /**
+     * Set the HTML contents of each element in the set of matched elements.
+     *
+     * @param htmlString A string of HTML to set as the content of each matched element.
+     */
+    html(htmlString: string): JQuery;
+    /**
+     * Set the HTML contents of each element in the set of matched elements.
+     *
+     * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
+     */
+    html(func: (index: number, oldhtml: string) => string): JQuery;
+    /**
+     * Set the HTML contents of each element in the set of matched elements.
+     *
+     * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
+     */
+
+    /**
+     * Get the value of a property for the first element in the set of matched elements.
+     *
+     * @param propertyName The name of the property to get.
+     */
+    prop(propertyName: string): any;
+    /**
+     * Set one or more properties for the set of matched elements.
+     *
+     * @param propertyName The name of the property to set.
+     * @param value A value to set for the property.
+     */
+    prop(propertyName: string, value: string|number|boolean): JQuery;
+    /**
+     * Set one or more properties for the set of matched elements.
+     *
+     * @param properties An object of property-value pairs to set.
+     */
+    prop(properties: Object): JQuery;
+    /**
+     * Set one or more properties for the set of matched elements.
+     *
+     * @param propertyName The name of the property to set.
+     * @param func A function returning the value to set. Receives the index position of the element in the set and the old property value as arguments. Within the function, the keyword this refers to the current element.
+     */
+    prop(propertyName: string, func: (index: number, oldPropertyValue: any) => any): JQuery;
+
+    /**
+     * Remove an attribute from each element in the set of matched elements.
+     *
+     * @param attributeName An attribute to remove; as of version 1.7, it can be a space-separated list of attributes.
+     */
+    removeAttr(attributeName: string): JQuery;
+
+    /**
+     * Remove a single class, multiple classes, or all classes from each element in the set of matched elements.
+     *
+     * @param className One or more space-separated classes to be removed from the class attribute of each matched element.
+     */
+    removeClass(className?: string): JQuery;
+    /**
+     * Remove a single class, multiple classes, or all classes from each element in the set of matched elements.
+     *
+     * @param function A function returning one or more space-separated class names to be removed. Receives the index position of the element in the set and the old class value as arguments.
+     */
+    removeClass(func: (index: number, className: string) => string): JQuery;
+
+    /**
+     * Remove a property for the set of matched elements.
+     *
+     * @param propertyName The name of the property to remove.
+     */
+    removeProp(propertyName: string): JQuery;
+
+    /**
+     * Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the switch argument.
+     *
+     * @param className One or more class names (separated by spaces) to be toggled for each element in the matched set.
+     * @param swtch A Boolean (not just truthy/falsy) value to determine whether the class should be added or removed.
+     */
+    toggleClass(className: string, swtch?: boolean): JQuery;
+    /**
+     * Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the switch argument.
+     *
+     * @param swtch A boolean value to determine whether the class should be added or removed.
+     */
+    toggleClass(swtch?: boolean): JQuery;
+    /**
+     * Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the switch argument.
+     *
+     * @param func A function that returns class names to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the switch as arguments.
+     * @param swtch A boolean value to determine whether the class should be added or removed.
+     */
+    toggleClass(func: (index: number, className: string, swtch: boolean) => string, swtch?: boolean): JQuery;
+
+    /**
+     * Get the current value of the first element in the set of matched elements.
+     */
+    val(): any;
+    /**
+     * Set the value of each element in the set of matched elements.
+     *
+     * @param value A string of text, an array of strings or number corresponding to the value of each matched element to set as selected/checked.
+     */
+    val(value: string|string[]|number): JQuery;
+    /**
+     * Set the value of each element in the set of matched elements.
+     *
+     * @param func A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old value as arguments.
+     */
+    val(func: (index: number, value: string) => string): JQuery;
+
+
+    /**
+     * Get the value of style properties for the first element in the set of matched elements.
+     *
+     * @param propertyName A CSS property.
+     */
+    css(propertyName: string): string;
+    /**
+     * Set one or more CSS properties for the set of matched elements.
+     *
+     * @param propertyName A CSS property name.
+     * @param value A value to set for the property.
+     */
+    css(propertyName: string, value: string|number): JQuery;
+    /**
+     * Set one or more CSS properties for the set of matched elements.
+     *
+     * @param propertyName A CSS property name.
+     * @param value A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old value as arguments.
+     */
+    css(propertyName: string, value: (index: number, value: string) => string|number): JQuery;
+    /**
+     * Set one or more CSS properties for the set of matched elements.
+     *
+     * @param properties An object of property-value pairs to set.
+     */
+    css(properties: Object): JQuery;
+
+    /**
+     * Get the current computed height for the first element in the set of matched elements.
+     */
+    height(): number;
+    /**
+     * Set the CSS height of every matched element.
+     *
+     * @param value An integer representing the number of pixels, or an integer with an optional unit of measure appended (as a string).
+     */
+    height(value: number|string): JQuery;
+    /**
+     * Set the CSS height of every matched element.
+     *
+     * @param func A function returning the height to set. Receives the index position of the element in the set and the old height as arguments. Within the function, this refers to the current element in the set.
+     */
+    height(func: (index: number, height: number) => number|string): JQuery;
+
+    /**
+     * Get the current computed height for the first element in the set of matched elements, including padding but not border.
+     */
+    innerHeight(): number;
+
+    /**
+     * Sets the inner height on elements in the set of matched elements, including padding but not border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    innerHeight(height: number|string): JQuery;
+    
+    /**
+     * Get the current computed width for the first element in the set of matched elements, including padding but not border.
+     */
+    innerWidth(): number;
+
+    /**
+     * Sets the inner width on elements in the set of matched elements, including padding but not border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    innerWidth(width: number|string): JQuery;
+    
+    /**
+     * Get the current coordinates of the first element in the set of matched elements, relative to the document.
+     */
+    offset(): JQueryCoordinates;
+    /**
+     * An object containing the properties top and left, which are integers indicating the new top and left coordinates for the elements.
+     *
+     * @param coordinates An object containing the properties top and left, which are integers indicating the new top and left coordinates for the elements.
+     */
+    offset(coordinates: JQueryCoordinates): JQuery;
+    /**
+     * An object containing the properties top and left, which are integers indicating the new top and left coordinates for the elements.
+     *
+     * @param func A function to return the coordinates to set. Receives the index of the element in the collection as the first argument and the current coordinates as the second argument. The function should return an object with the new top and left properties.
+     */
+    offset(func: (index: number, coords: JQueryCoordinates) => JQueryCoordinates): JQuery;
+
+    /**
+     * Get the current computed height for the first element in the set of matched elements, including padding, border, and optionally margin. Returns an integer (without "px") representation of the value or null if called on an empty set of elements.
+     *
+     * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
+     */
+    outerHeight(includeMargin?: boolean): number;
+
+    /**
+     * Sets the outer height on elements in the set of matched elements, including padding and border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    outerHeight(height: number|string): JQuery;
+
+    /**
+     * Get the current computed width for the first element in the set of matched elements, including padding and border.
+     *
+     * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
+     */
+    outerWidth(includeMargin?: boolean): number;
+
+    /**
+     * Sets the outer width on elements in the set of matched elements, including padding and border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    outerWidth(width: number|string): JQuery;
+
+    /**
+     * Get the current coordinates of the first element in the set of matched elements, relative to the offset parent.
+     */
+    position(): JQueryCoordinates;
+
+    /**
+     * Get the current horizontal position of the scroll bar for the first element in the set of matched elements or set the horizontal position of the scroll bar for every matched element.
+     */
+    scrollLeft(): number;
+    /**
+     * Set the current horizontal position of the scroll bar for each of the set of matched elements.
+     *
+     * @param value An integer indicating the new position to set the scroll bar to.
+     */
+    scrollLeft(value: number): JQuery;
+
+    /**
+     * Get the current vertical position of the scroll bar for the first element in the set of matched elements or set the vertical position of the scroll bar for every matched element.
+     */
+    scrollTop(): number;
+    /**
+     * Set the current vertical position of the scroll bar for each of the set of matched elements.
+     *
+     * @param value An integer indicating the new position to set the scroll bar to.
+     */
+    scrollTop(value: number): JQuery;
+
+    /**
+     * Get the current computed width for the first element in the set of matched elements.
+     */
+    width(): number;
+    /**
+     * Set the CSS width of each element in the set of matched elements.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    width(value: number|string): JQuery;
+    /**
+     * Set the CSS width of each element in the set of matched elements.
+     *
+     * @param func A function returning the width to set. Receives the index position of the element in the set and the old width as arguments. Within the function, this refers to the current element in the set.
+     */
+    width(func: (index: number, width: number) => number|string): JQuery;
+
+    /**
+     * Remove from the queue all items that have not yet been run.
+     *
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     */
+    clearQueue(queueName?: string): JQuery;
+
+    /**
+     * Store arbitrary data associated with the matched elements.
+     *
+     * @param key A string naming the piece of data to set.
+     * @param value The new data value; it can be any Javascript type including Array or Object.
+     */
+    data(key: string, value: any): JQuery;
+    /**
+     * Return the value at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.
+     *
+     * @param key Name of the data stored.
+     */
+    data(key: string): any;
+    /**
+     * Store arbitrary data associated with the matched elements.
+     *
+     * @param obj An object of key-value pairs of data to update.
+     */
+    data(obj: { [key: string]: any; }): JQuery;
+    /**
+     * Return the value at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.
+     */
+    data(): any;
+
+    /**
+     * Execute the next function on the queue for the matched elements.
+     *
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     */
+    dequeue(queueName?: string): JQuery;
+
+    /**
+     * Remove a previously-stored piece of data.
+     *
+     * @param name A string naming the piece of data to delete or space-separated string naming the pieces of data to delete.
+     */
+    removeData(name: string): JQuery;
+    /**
+     * Remove a previously-stored piece of data.
+     *
+     * @param list An array of strings naming the pieces of data to delete.
+     */
+    removeData(list: string[]): JQuery;
+    /**
+     * Remove all previously-stored piece of data.
+     */
+    removeData(): JQuery;
+
+    /**
+     * Return a Promise object to observe when all actions of a certain type bound to the collection, queued or not, have finished.
+     *
+     * @param type The type of queue that needs to be observed. (default: fx)
+     * @param target Object onto which the promise methods have to be attached
+     */
+    promise(type?: string, target?: Object): JQueryPromise<any>;
+
+    /**
+     * Perform a custom animation of a set of CSS properties.
+     *
+     * @param properties An object of CSS properties and values that the animation will move toward.
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    animate(properties: Object, duration?: string|number, complete?: Function): JQuery;
+    /**
+     * Perform a custom animation of a set of CSS properties.
+     *
+     * @param properties An object of CSS properties and values that the animation will move toward.
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition. (default: swing)
+     * @param complete A function to call once the animation is complete.
+     */
+    animate(properties: Object, duration?: string|number, easing?: string, complete?: Function): JQuery;
+    /**
+     * Perform a custom animation of a set of CSS properties.
+     *
+     * @param properties An object of CSS properties and values that the animation will move toward.
+     * @param options A map of additional options to pass to the method.
+     */
+    animate(properties: Object, options: JQueryAnimationOptions): JQuery;
+
+    /**
+     * Set a timer to delay execution of subsequent items in the queue.
+     *
+     * @param duration An integer indicating the number of milliseconds to delay execution of the next item in the queue.
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     */
+    delay(duration: number, queueName?: string): JQuery;
+
+    /**
+     * Display the matched elements by fading them to opaque.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    fadeIn(duration?: number|string, complete?: Function): JQuery;
+    /**
+     * Display the matched elements by fading them to opaque.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    fadeIn(duration?: number|string, easing?: string, complete?: Function): JQuery;
+    /**
+     * Display the matched elements by fading them to opaque.
+     *
+     * @param options A map of additional options to pass to the method.
+     */
+    fadeIn(options: JQueryAnimationOptions): JQuery;
+
+    /**
+     * Hide the matched elements by fading them to transparent.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    fadeOut(duration?: number|string, complete?: Function): JQuery;
+    /**
+     * Hide the matched elements by fading them to transparent.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    fadeOut(duration?: number|string, easing?: string, complete?: Function): JQuery;
+    /**
+     * Hide the matched elements by fading them to transparent.
+     *
+     * @param options A map of additional options to pass to the method.
+     */
+    fadeOut(options: JQueryAnimationOptions): JQuery;
+
+    /**
+     * Adjust the opacity of the matched elements.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param opacity A number between 0 and 1 denoting the target opacity.
+     * @param complete A function to call once the animation is complete.
+     */
+    fadeTo(duration: string|number, opacity: number, complete?: Function): JQuery;
+    /**
+     * Adjust the opacity of the matched elements.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param opacity A number between 0 and 1 denoting the target opacity.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    fadeTo(duration: string|number, opacity: number, easing?: string, complete?: Function): JQuery;
+
+    /**
+     * Display or hide the matched elements by animating their opacity.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    fadeToggle(duration?: number|string, complete?: Function): JQuery;
+    /**
+     * Display or hide the matched elements by animating their opacity.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    fadeToggle(duration?: number|string, easing?: string, complete?: Function): JQuery;
+    /**
+     * Display or hide the matched elements by animating their opacity.
+     *
+     * @param options A map of additional options to pass to the method.
+     */
+    fadeToggle(options: JQueryAnimationOptions): JQuery;
+
+    /**
+     * Stop the currently-running animation, remove all queued animations, and complete all animations for the matched elements.
+     *
+     * @param queue The name of the queue in which to stop animations.
+     */
+    finish(queue?: string): JQuery;
+
+    /**
+     * Hide the matched elements.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    hide(duration?: number|string, complete?: Function): JQuery;
+    /**
+     * Hide the matched elements.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    hide(duration?: number|string, easing?: string, complete?: Function): JQuery;
+    /**
+     * Hide the matched elements.
+     *
+     * @param options A map of additional options to pass to the method.
+     */
+    hide(options: JQueryAnimationOptions): JQuery;
+
+    /**
+     * Display the matched elements.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    show(duration?: number|string, complete?: Function): JQuery;
+    /**
+     * Display the matched elements.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    show(duration?: number|string, easing?: string, complete?: Function): JQuery;
+    /**
+     * Display the matched elements.
+     *
+     * @param options A map of additional options to pass to the method.
+     */
+    show(options: JQueryAnimationOptions): JQuery;
+
+    /**
+     * Display the matched elements with a sliding motion.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    slideDown(duration?: number|string, complete?: Function): JQuery;
+    /**
+     * Display the matched elements with a sliding motion.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    slideDown(duration?: number|string, easing?: string, complete?: Function): JQuery;
+    /**
+     * Display the matched elements with a sliding motion.
+     *
+     * @param options A map of additional options to pass to the method.
+     */
+    slideDown(options: JQueryAnimationOptions): JQuery;
+
+    /**
+     * Display or hide the matched elements with a sliding motion.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    slideToggle(duration?: number|string, complete?: Function): JQuery;
+    /**
+     * Display or hide the matched elements with a sliding motion.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    slideToggle(duration?: number|string, easing?: string, complete?: Function): JQuery;
+    /**
+     * Display or hide the matched elements with a sliding motion.
+     *
+     * @param options A map of additional options to pass to the method.
+     */
+    slideToggle(options: JQueryAnimationOptions): JQuery;
+
+    /**
+     * Hide the matched elements with a sliding motion.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    slideUp(duration?: number|string, complete?: Function): JQuery;
+    /**
+     * Hide the matched elements with a sliding motion.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    slideUp(duration?: number|string, easing?: string, complete?: Function): JQuery;
+    /**
+     * Hide the matched elements with a sliding motion.
+     *
+     * @param options A map of additional options to pass to the method.
+     */
+    slideUp(options: JQueryAnimationOptions): JQuery;
+
+    /**
+     * Stop the currently-running animation on the matched elements.
+     *
+     * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
+     * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
+     */
+    stop(clearQueue?: boolean, jumpToEnd?: boolean): JQuery;
+    /**
+     * Stop the currently-running animation on the matched elements.
+     *
+     * @param queue The name of the queue in which to stop animations.
+     * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
+     * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
+     */
+    stop(queue?: string, clearQueue?: boolean, jumpToEnd?: boolean): JQuery;
+
+    /**
+     * Display or hide the matched elements.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param complete A function to call once the animation is complete.
+     */
+    toggle(duration?: number|string, complete?: Function): JQuery;
+    /**
+     * Display or hide the matched elements.
+     *
+     * @param duration A string or number determining how long the animation will run.
+     * @param easing A string indicating which easing function to use for the transition.
+     * @param complete A function to call once the animation is complete.
+     */
+    toggle(duration?: number|string, easing?: string, complete?: Function): JQuery;
+    /**
+     * Display or hide the matched elements.
+     *
+     * @param options A map of additional options to pass to the method.
+     */
+    toggle(options: JQueryAnimationOptions): JQuery;
+    /**
+     * Display or hide the matched elements.
+     *
+     * @param showOrHide A Boolean indicating whether to show or hide the elements.
+     */
+    toggle(showOrHide: boolean): JQuery;
+
+    /**
+     * Attach a handler to an event for the elements.
+     * 
+     * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    bind(eventType: string, eventData: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Attach a handler to an event for the elements.
+     * 
+     * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    bind(eventType: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Attach a handler to an event for the elements.
+     * 
+     * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param preventBubble Setting the third argument to false will attach a function that prevents the default action from occurring and stops the event from bubbling. The default is true.
+     */
+    bind(eventType: string, eventData: any, preventBubble: boolean): JQuery;
+    /**
+     * Attach a handler to an event for the elements.
+     * 
+     * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
+     * @param preventBubble Setting the third argument to false will attach a function that prevents the default action from occurring and stops the event from bubbling. The default is true.
+     */
+    bind(eventType: string, preventBubble: boolean): JQuery;
+    /**
+     * Attach a handler to an event for the elements.
+     * 
+     * @param events An object containing one or more DOM event types and functions to execute for them.
+     */
+    bind(events: any): JQuery;
+
+    /**
+     * Trigger the "blur" event on an element
+     */
+    blur(): JQuery;
+    /**
+     * Bind an event handler to the "blur" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    blur(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "blur" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    blur(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "change" event on an element.
+     */
+    change(): JQuery;
+    /**
+     * Bind an event handler to the "change" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    change(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "change" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    change(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "click" event on an element.
+     */
+    click(): JQuery;
+    /**
+     * Bind an event handler to the "click" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     */
+    click(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "click" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    click(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "dblclick" event on an element.
+     */
+    dblclick(): JQuery;
+    /**
+     * Bind an event handler to the "dblclick" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    dblclick(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "dblclick" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    dblclick(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+
+    delegate(selector: any, eventType: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
+    delegate(selector: any, eventType: string, eventData: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "focus" event on an element.
+     */
+    focus(): JQuery;
+    /**
+     * Bind an event handler to the "focus" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    focus(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "focus" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    focus(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "focusin" event on an element.
+     */
+    focusin(): JQuery;
+    /**
+     * Bind an event handler to the "focusin" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    focusin(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "focusin" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    focusin(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "focusout" event on an element.
+     */
+    focusout(): JQuery;
+    /**
+     * Bind an event handler to the "focusout" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    focusout(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "focusout" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    focusout(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Bind two handlers to the matched elements, to be executed when the mouse pointer enters and leaves the elements.
+     *
+     * @param handlerIn A function to execute when the mouse pointer enters the element.
+     * @param handlerOut A function to execute when the mouse pointer leaves the element.
+     */
+    hover(handlerIn: (eventObject: JQueryEventObject) => any, handlerOut: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind a single handler to the matched elements, to be executed when the mouse pointer enters or leaves the elements.
+     *
+     * @param handlerInOut A function to execute when the mouse pointer enters or leaves the element.
+     */
+    hover(handlerInOut: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "keydown" event on an element.
+     */
+    keydown(): JQuery;
+    /**
+     * Bind an event handler to the "keydown" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    keydown(handler: (eventObject: JQueryKeyEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "keydown" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    keydown(eventData?: any, handler?: (eventObject: JQueryKeyEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "keypress" event on an element.
+     */
+    keypress(): JQuery;
+    /**
+     * Bind an event handler to the "keypress" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    keypress(handler: (eventObject: JQueryKeyEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "keypress" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    keypress(eventData?: any, handler?: (eventObject: JQueryKeyEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "keyup" event on an element.
+     */
+    keyup(): JQuery;
+    /**
+     * Bind an event handler to the "keyup" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    keyup(handler: (eventObject: JQueryKeyEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "keyup" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    keyup(eventData?: any, handler?: (eventObject: JQueryKeyEventObject) => any): JQuery;
+
+    /**
+     * Bind an event handler to the "load" JavaScript event.
+     *
+     * @param handler A function to execute when the event is triggered.
+     */
+    load(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "load" JavaScript event.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    load(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "mousedown" event on an element.
+     */
+    mousedown(): JQuery;
+    /**
+     * Bind an event handler to the "mousedown" JavaScript event.
+     *
+     * @param handler A function to execute when the event is triggered.
+     */
+    mousedown(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "mousedown" JavaScript event.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    mousedown(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "mouseenter" event on an element.
+     */
+    mouseenter(): JQuery;
+    /**
+     * Bind an event handler to be fired when the mouse enters an element.
+     *
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseenter(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to be fired when the mouse enters an element.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseenter(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "mouseleave" event on an element.
+     */
+    mouseleave(): JQuery;
+    /**
+     * Bind an event handler to be fired when the mouse leaves an element.
+     *
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseleave(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to be fired when the mouse leaves an element.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseleave(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "mousemove" event on an element.
+     */
+    mousemove(): JQuery;
+    /**
+     * Bind an event handler to the "mousemove" JavaScript event.
+     *
+     * @param handler A function to execute when the event is triggered.
+     */
+    mousemove(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "mousemove" JavaScript event.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    mousemove(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "mouseout" event on an element.
+     */
+    mouseout(): JQuery;
+    /**
+     * Bind an event handler to the "mouseout" JavaScript event.
+     *
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseout(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "mouseout" JavaScript event.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseout(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "mouseover" event on an element.
+     */
+    mouseover(): JQuery;
+    /**
+     * Bind an event handler to the "mouseover" JavaScript event.
+     *
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseover(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "mouseover" JavaScript event.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseover(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "mouseup" event on an element.
+     */
+    mouseup(): JQuery;
+    /**
+     * Bind an event handler to the "mouseup" JavaScript event.
+     *
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseup(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "mouseup" JavaScript event.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    mouseup(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
+
+    /**
+     * Remove an event handler.
+     */
+    off(): JQuery;
+    /**
+     * Remove an event handler.
+     *
+     * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin".
+     * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
+     * @param handler A handler function previously attached for the event(s), or the special value false.
+     */
+    off(events: string, selector?: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Remove an event handler.
+     *
+     * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin".
+     * @param handler A handler function previously attached for the event(s), or the special value false.
+     */
+    off(events: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Remove an event handler.
+     *
+     * @param events An object where the string keys represent one or more space-separated event types and optional namespaces, and the values represent handler functions previously attached for the event(s).
+     * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
+     */
+    off(events: { [key: string]: any; }, selector?: string): JQuery;
+
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false. Rest parameter args is for optional parameters passed to jQuery.trigger(). Note that the actual parameters on the event handler function must be marked as optional (? syntax).
+     */
+    on(events: string, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param data Data to be passed to the handler in event.data when an event is triggered.
+     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+    */
+    on(events: string, data : any, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     */
+    on(events: string, selector: string, handler: (eventObject: JQueryEventObject, ...eventData: any[]) => any): JQuery;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event is triggered.
+     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     */
+    on(events: string, selector: string, data: any, handler: (eventObject: JQueryEventObject, ...eventData: any[]) => any): JQuery;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event occurs.
+     */
+    on(events: { [key: string]: any; }, selector?: string, data?: any): JQuery;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
+     * @param data Data to be passed to the handler in event.data when an event occurs.
+     */
+    on(events: { [key: string]: any; }, data?: any): JQuery;
+
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     *
+     * @param events A string containing one or more JavaScript event types, such as "click" or "submit," or custom event names.
+     * @param handler A function to execute at the time the event is triggered.
+     */
+    one(events: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     *
+     * @param events A string containing one or more JavaScript event types, such as "click" or "submit," or custom event names.
+     * @param data An object containing data that will be passed to the event handler.
+     * @param handler A function to execute at the time the event is triggered.
+     */
+    one(events: string, data: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     *
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     */
+    one(events: string, selector: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     *
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event is triggered.
+     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     */
+    one(events: string, selector: string, data: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event occurs.
+     */
+    one(events: { [key: string]: any; }, selector?: string, data?: any): JQuery;
+
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
+     * @param data Data to be passed to the handler in event.data when an event occurs.
+     */
+    one(events: { [key: string]: any; }, data?: any): JQuery;
+
+
+    /**
+     * Specify a function to execute when the DOM is fully loaded.
+     *
+     * @param handler A function to execute after the DOM is ready.
+     */
+    ready(handler: (jQueryAlias?: JQueryStatic) => any): JQuery;
+
+    /**
+     * Trigger the "resize" event on an element.
+     */
+    resize(): JQuery;
+    /**
+     * Bind an event handler to the "resize" JavaScript event.
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    resize(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "resize" JavaScript event.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    resize(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "scroll" event on an element.
+     */
+    scroll(): JQuery;
+    /**
+     * Bind an event handler to the "scroll" JavaScript event.
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    scroll(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "scroll" JavaScript event.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    scroll(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "select" event on an element.
+     */
+    select(): JQuery;
+    /**
+     * Bind an event handler to the "select" JavaScript event.
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    select(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "select" JavaScript event.
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    select(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Trigger the "submit" event on an element.
+     */
+    submit(): JQuery;
+    /**
+     * Bind an event handler to the "submit" JavaScript event
+     *
+     * @param handler A function to execute each time the event is triggered.
+     */
+    submit(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "submit" JavaScript event
+     *
+     * @param eventData An object containing data that will be passed to the event handler.
+     * @param handler A function to execute each time the event is triggered.
+     */
+    submit(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Execute all handlers and behaviors attached to the matched elements for the given event type.
+     * 
+     * @param eventType A string containing a JavaScript event type, such as click or submit.
+     * @param extraParameters Additional parameters to pass along to the event handler.
+     */
+    trigger(eventType: string, extraParameters?: any[]|Object): JQuery;
+    /**
+     * Execute all handlers and behaviors attached to the matched elements for the given event type.
+     * 
+     * @param event A jQuery.Event object.
+     * @param extraParameters Additional parameters to pass along to the event handler.
+     */
+    trigger(event: JQueryEventObject, extraParameters?: any[]|Object): JQuery;
+
+    /**
+     * Execute all handlers attached to an element for an event.
+     * 
+     * @param eventType A string containing a JavaScript event type, such as click or submit.
+     * @param extraParameters An array of additional parameters to pass along to the event handler.
+     */
+    triggerHandler(eventType: string, ...extraParameters: any[]): Object;
+
+    /**
+     * Execute all handlers attached to an element for an event.
+     * 
+     * @param event A jQuery.Event object.
+     * @param extraParameters An array of additional parameters to pass along to the event handler.
+     */
+    triggerHandler(event: JQueryEventObject, ...extraParameters: any[]): Object;
+
+    /**
+     * Remove a previously-attached event handler from the elements.
+     * 
+     * @param eventType A string containing a JavaScript event type, such as click or submit.
+     * @param handler The function that is to be no longer executed.
+     */
+    unbind(eventType?: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Remove a previously-attached event handler from the elements.
+     * 
+     * @param eventType A string containing a JavaScript event type, such as click or submit.
+     * @param fls Unbinds the corresponding 'return false' function that was bound using .bind( eventType, false ).
+     */
+    unbind(eventType: string, fls: boolean): JQuery;
+    /**
+     * Remove a previously-attached event handler from the elements.
+     * 
+     * @param evt A JavaScript event object as passed to an event handler.
+     */
+    unbind(evt: any): JQuery;
+
+    /**
+     * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
+     */
+    undelegate(): JQuery;
+    /**
+     * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
+     * 
+     * @param selector A selector which will be used to filter the event results.
+     * @param eventType A string containing a JavaScript event type, such as "click" or "keydown"
+     * @param handler A function to execute at the time the event is triggered.
+     */
+    undelegate(selector: string, eventType: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
+     * 
+     * @param selector A selector which will be used to filter the event results.
+     * @param events An object of one or more event types and previously bound functions to unbind from them.
+     */
+    undelegate(selector: string, events: Object): JQuery;
+    /**
+     * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
+     * 
+     * @param namespace A string containing a namespace to unbind all events from.
+     */
+    undelegate(namespace: string): JQuery;
+
+    /**
+     * Bind an event handler to the "unload" JavaScript event. (DEPRECATED from v1.8)
+     * 
+     * @param handler A function to execute when the event is triggered.
+     */
+    unload(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "unload" JavaScript event. (DEPRECATED from v1.8)
+     * 
+     * @param eventData A plain object of data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    unload(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * The DOM node context originally passed to jQuery(); if none was passed then context will likely be the document. (DEPRECATED from v1.10)
+     */
+    context: Element;
+
+    jquery: string;
+
+    /**
+     * Bind an event handler to the "error" JavaScript event. (DEPRECATED from v1.8)
+     * 
+     * @param handler A function to execute when the event is triggered.
+     */
+    error(handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Bind an event handler to the "error" JavaScript event. (DEPRECATED from v1.8)
+     * 
+     * @param eventData A plain object of data that will be passed to the event handler.
+     * @param handler A function to execute when the event is triggered.
+     */
+    error(eventData: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
+
+    /**
+     * Add a collection of DOM elements onto the jQuery stack.
+     * 
+     * @param elements An array of elements to push onto the stack and make into a new jQuery object.
+     */
+    pushStack(elements: any[]): JQuery;
+    /**
+     * Add a collection of DOM elements onto the jQuery stack.
+     * 
+     * @param elements An array of elements to push onto the stack and make into a new jQuery object.
+     * @param name The name of a jQuery method that generated the array of elements.
+     * @param arguments The arguments that were passed in to the jQuery method (for serialization).
+     */
+    pushStack(elements: any[], name: string, arguments: any[]): JQuery;
+
+    /**
+     * Insert content, specified by the parameter, after each element in the set of matched elements.
+     * 
+     * param content1 HTML string, DOM element, array of elements, or jQuery object to insert after each element in the set of matched elements.
+     * param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert after each element in the set of matched elements.
+     */
+    after(content1: JQuery|any[]|Element|Text|string, ...content2: any[]): JQuery;
+    /**
+     * Insert content, specified by the parameter, after each element in the set of matched elements.
+     * 
+     * param func A function that returns an HTML string, DOM element(s), or jQuery object to insert after each element in the set of matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     */
+    after(func: (index: number, html: string) => string|Element|JQuery): JQuery;
+
+    /**
+     * Insert content, specified by the parameter, to the end of each element in the set of matched elements.
+     * 
+     * param content1 DOM element, array of elements, HTML string, or jQuery object to insert at the end of each element in the set of matched elements.
+     * param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert at the end of each element in the set of matched elements.
+     */
+    append(content1: JQuery|any[]|Element|Text|string, ...content2: any[]): JQuery;
+    /**
+     * Insert content, specified by the parameter, to the end of each element in the set of matched elements.
+     * 
+     * param func A function that returns an HTML string, DOM element(s), or jQuery object to insert at the end of each element in the set of matched elements. Receives the index position of the element in the set and the old HTML value of the element as arguments. Within the function, this refers to the current element in the set.
+     */
+    append(func: (index: number, html: string) => string|Element|JQuery): JQuery;
+
+    /**
+     * Insert every element in the set of matched elements to the end of the target.
+     * 
+     * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements will be inserted at the end of the element(s) specified by this parameter.
+     */
+    appendTo(target: JQuery|any[]|Element|string): JQuery;
+
+    /**
+     * Insert content, specified by the parameter, before each element in the set of matched elements.
+     * 
+     * param content1 HTML string, DOM element, array of elements, or jQuery object to insert before each element in the set of matched elements.
+     * param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert before each element in the set of matched elements.
+     */
+    before(content1: JQuery|any[]|Element|Text|string, ...content2: any[]): JQuery;
+    /**
+     * Insert content, specified by the parameter, before each element in the set of matched elements.
+     * 
+     * param func A function that returns an HTML string, DOM element(s), or jQuery object to insert before each element in the set of matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     */
+    before(func: (index: number, html: string) => string|Element|JQuery): JQuery;
+
+    /**
+     * Create a deep copy of the set of matched elements.
+     * 
+     * param withDataAndEvents A Boolean indicating whether event handlers and data should be copied along with the elements. The default value is false.
+     * param deepWithDataAndEvents A Boolean indicating whether event handlers and data for all children of the cloned element should be copied. By default its value matches the first argument's value (which defaults to false).
+     */
+    clone(withDataAndEvents?: boolean, deepWithDataAndEvents?: boolean): JQuery;
+
+    /**
+     * Remove the set of matched elements from the DOM.
+     * 
+     * param selector A selector expression that filters the set of matched elements to be removed.
+     */
+    detach(selector?: string): JQuery;
+
+    /**
+     * Remove all child nodes of the set of matched elements from the DOM.
+     */
+    empty(): JQuery;
+
+    /**
+     * Insert every element in the set of matched elements after the target.
+     * 
+     * param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements will be inserted after the element(s) specified by this parameter.
+     */
+    insertAfter(target: JQuery|any[]|Element|Text|string): JQuery;
+
+    /**
+     * Insert every element in the set of matched elements before the target.
+     * 
+     * param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements will be inserted before the element(s) specified by this parameter.
+     */
+    insertBefore(target: JQuery|any[]|Element|Text|string): JQuery;
+
+    /**
+     * Insert content, specified by the parameter, to the beginning of each element in the set of matched elements.
+     * 
+     * param content1 DOM element, array of elements, HTML string, or jQuery object to insert at the beginning of each element in the set of matched elements.
+     * param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert at the beginning of each element in the set of matched elements.
+     */
+    prepend(content1: JQuery|any[]|Element|Text|string, ...content2: any[]): JQuery;
+    /**
+     * Insert content, specified by the parameter, to the beginning of each element in the set of matched elements.
+     * 
+     * param func A function that returns an HTML string, DOM element(s), or jQuery object to insert at the beginning of each element in the set of matched elements. Receives the index position of the element in the set and the old HTML value of the element as arguments. Within the function, this refers to the current element in the set.
+     */
+    prepend(func: (index: number, html: string) => string|Element|JQuery): JQuery;
+
+    /**
+     * Insert every element in the set of matched elements to the beginning of the target.
+     * 
+     * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements will be inserted at the beginning of the element(s) specified by this parameter.
+     */
+    prependTo(target: JQuery|any[]|Element|string): JQuery;
+
+    /**
+     * Remove the set of matched elements from the DOM.
+     * 
+     * @param selector A selector expression that filters the set of matched elements to be removed.
+     */
+    remove(selector?: string): JQuery;
+
+    /**
+     * Replace each target element with the set of matched elements.
+     * 
+     * @param target A selector string, jQuery object, DOM element, or array of elements indicating which element(s) to replace.
+     */
+    replaceAll(target: JQuery|any[]|Element|string): JQuery;
+
+    /**
+     * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
+     * 
+     * param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
+     */
+    replaceWith(newContent: JQuery|any[]|Element|Text|string): JQuery;
+    /**
+     * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
+     * 
+     * param func A function that returns content with which to replace the set of matched elements.
+     */
+    replaceWith(func: () => Element|JQuery): JQuery;
+
+    /**
+     * Get the combined text contents of each element in the set of matched elements, including their descendants.
+     */
+    text(): string;
+    /**
+     * Set the content of each element in the set of matched elements to the specified text.
+     * 
+     * @param text The text to set as the content of each matched element. When Number or Boolean is supplied, it will be converted to a String representation.
+     */
+    text(text: string|number|boolean): JQuery;
+    /**
+     * Set the content of each element in the set of matched elements to the specified text.
+     * 
+     * @param func A function returning the text content to set. Receives the index position of the element in the set and the old text value as arguments.
+     */
+    text(func: (index: number, text: string) => string): JQuery;
+
+    /**
+     * Retrieve all the elements contained in the jQuery set, as an array.
+     */
+    toArray(): any[];
+
+    /**
+     * Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.
+     */
+    unwrap(): JQuery;
+
+    /**
+     * Wrap an HTML structure around each element in the set of matched elements.
+     * 
+     * @param wrappingElement A selector, element, HTML string, or jQuery object specifying the structure to wrap around the matched elements.
+     */
+    wrap(wrappingElement: JQuery|Element|string): JQuery;
+    /**
+     * Wrap an HTML structure around each element in the set of matched elements.
+     * 
+     * @param func A callback function returning the HTML content or jQuery object to wrap around the matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     */
+    wrap(func: (index: number) => string|JQuery): JQuery;
+
+    /**
+     * Wrap an HTML structure around all elements in the set of matched elements.
+     * 
+     * @param wrappingElement A selector, element, HTML string, or jQuery object specifying the structure to wrap around the matched elements.
+     */
+    wrapAll(wrappingElement: JQuery|Element|string): JQuery;
+    wrapAll(func: (index: number) => string): JQuery;
+
+    /**
+     * Wrap an HTML structure around the content of each element in the set of matched elements.
+     * 
+     * @param wrappingElement An HTML snippet, selector expression, jQuery object, or DOM element specifying the structure to wrap around the content of the matched elements.
+     */
+    wrapInner(wrappingElement: JQuery|Element|string): JQuery;
+    /**
+     * Wrap an HTML structure around the content of each element in the set of matched elements.
+     * 
+     * @param func A callback function which generates a structure to wrap around the content of the matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     */
+    wrapInner(func: (index: number) => string): JQuery;
+
+    /**
+     * Iterate over a jQuery object, executing a function for each matched element.
+     * 
+     * @param func A function to execute for each matched element.
+     */
+    each(func: (index: number, elem: Element) => any): JQuery;
+
+    /**
+     * Retrieve one of the elements matched by the jQuery object.
+     * 
+     * @param index A zero-based integer indicating which element to retrieve.
+     */
+    get(index: number): HTMLElement;
+    /**
+     * Retrieve the elements matched by the jQuery object.
+     */
+    get(): any[];
+
+    /**
+     * Search for a given element from among the matched elements.
+     */
+    index(): number;
+    /**
+     * Search for a given element from among the matched elements.
+     * 
+     * @param selector A selector representing a jQuery collection in which to look for an element.
+     */
+    index(selector: string|JQuery|Element): number;
+
+    /**
+     * The number of elements in the jQuery object.
+     */
+    length: number;
+    /**
+     * A selector representing selector passed to jQuery(), if any, when creating the original set.
+     * version deprecated: 1.7, removed: 1.9
+     */
+    selector: string;
+    [index: string]: any;
+    [index: number]: HTMLElement;
+
+    /**
+     * Add elements to the set of matched elements.
+     * 
+     * @param selector A string representing a selector expression to find additional elements to add to the set of matched elements.
+     * @param context The point in the document at which the selector should begin matching; similar to the context argument of the $(selector, context) method.
+     */
+    add(selector: string, context?: Element): JQuery;
+    /**
+     * Add elements to the set of matched elements.
+     * 
+     * @param elements One or more elements to add to the set of matched elements.
+     */
+    add(...elements: Element[]): JQuery;
+    /**
+     * Add elements to the set of matched elements.
+     * 
+     * @param html An HTML fragment to add to the set of matched elements.
+     */
+    add(html: string): JQuery;
+    /**
+     * Add elements to the set of matched elements.
+     * 
+     * @param obj An existing jQuery object to add to the set of matched elements.
+     */
+    add(obj: JQuery): JQuery;
+
+    /**
+     * Get the children of each element in the set of matched elements, optionally filtered by a selector.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    children(selector?: string): JQuery;
+
+    /**
+     * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    closest(selector: string): JQuery;
+    /**
+     * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     * @param context A DOM element within which a matching element may be found. If no context is passed in then the context of the jQuery set will be used instead.
+     */
+    closest(selector: string, context?: Element): JQuery;
+    /**
+     * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
+     * 
+     * @param obj A jQuery object to match elements against.
+     */
+    closest(obj: JQuery): JQuery;
+    /**
+     * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
+     * 
+     * @param element An element to match elements against.
+     */
+    closest(element: Element): JQuery;
+
+    /**
+     * Get an array of all the elements and selectors matched against the current element up through the DOM tree.
+     * 
+     * @param selectors An array or string containing a selector expression to match elements against (can also be a jQuery object).
+     * @param context A DOM element within which a matching element may be found. If no context is passed in then the context of the jQuery set will be used instead.
+     */
+    closest(selectors: any, context?: Element): any[];
+
+    /**
+     * Get the children of each element in the set of matched elements, including text and comment nodes.
+     */
+    contents(): JQuery;
+
+    /**
+     * End the most recent filtering operation in the current chain and return the set of matched elements to its previous state.
+     */
+    end(): JQuery;
+
+    /**
+     * Reduce the set of matched elements to the one at the specified index.
+     * 
+     * @param index An integer indicating the 0-based position of the element. OR An integer indicating the position of the element, counting backwards from the last element in the set.
+     *  
+     */
+    eq(index: number): JQuery;
+
+    /**
+     * Reduce the set of matched elements to those that match the selector or pass the function's test.
+     * 
+     * @param selector A string containing a selector expression to match the current set of elements against.
+     */
+    filter(selector: string): JQuery;
+    /**
+     * Reduce the set of matched elements to those that match the selector or pass the function's test.
+     * 
+     * @param func A function used as a test for each element in the set. this is the current DOM element.
+     */
+    filter(func: (index: number, element: Element) => any): JQuery;
+    /**
+     * Reduce the set of matched elements to those that match the selector or pass the function's test.
+     * 
+     * @param element An element to match the current set of elements against.
+     */
+    filter(element: Element): JQuery;
+    /**
+     * Reduce the set of matched elements to those that match the selector or pass the function's test.
+     * 
+     * @param obj An existing jQuery object to match the current set of elements against.
+     */
+    filter(obj: JQuery): JQuery;
+
+    /**
+     * Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    find(selector: string): JQuery;
+    /**
+     * Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.
+     * 
+     * @param element An element to match elements against.
+     */
+    find(element: Element): JQuery;
+    /**
+     * Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.
+     * 
+     * @param obj A jQuery object to match elements against.
+     */
+    find(obj: JQuery): JQuery;
+
+    /**
+     * Reduce the set of matched elements to the first in the set.
+     */
+    first(): JQuery;
+
+    /**
+     * Reduce the set of matched elements to those that have a descendant that matches the selector or DOM element.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    has(selector: string): JQuery;
+    /**
+     * Reduce the set of matched elements to those that have a descendant that matches the selector or DOM element.
+     * 
+     * @param contained A DOM element to match elements against.
+     */
+    has(contained: Element): JQuery;
+
+    /**
+     * Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    is(selector: string): boolean;
+    /**
+     * Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.
+     * 
+     * @param func A function used as a test for the set of elements. It accepts one argument, index, which is the element's index in the jQuery collection.Within the function, this refers to the current DOM element.
+     */
+    is(func: (index: number, element: Element) => boolean): boolean;
+    /**
+     * Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.
+     * 
+     * @param obj An existing jQuery object to match the current set of elements against.
+     */
+    is(obj: JQuery): boolean;
+    /**
+     * Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.
+     * 
+     * @param elements One or more elements to match the current set of elements against.
+     */
+    is(elements: any): boolean;
+
+    /**
+     * Reduce the set of matched elements to the final one in the set.
+     */
+    last(): JQuery;
+
+    /**
+     * Pass each element in the current matched set through a function, producing a new jQuery object containing the return values.
+     * 
+     * @param callback A function object that will be invoked for each element in the current set.
+     */
+    map(callback: (index: number, domElement: Element) => any): JQuery;
+
+    /**
+     * Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    next(selector?: string): JQuery;
+
+    /**
+     * Get all following siblings of each element in the set of matched elements, optionally filtered by a selector.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    nextAll(selector?: string): JQuery;
+
+    /**
+     * Get all following siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object passed.
+     * 
+     * @param selector A string containing a selector expression to indicate where to stop matching following sibling elements.
+     * @param filter A string containing a selector expression to match elements against.
+     */
+    nextUntil(selector?: string, filter?: string): JQuery;
+    /**
+     * Get all following siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object passed.
+     * 
+     * @param element A DOM node or jQuery object indicating where to stop matching following sibling elements.
+     * @param filter A string containing a selector expression to match elements against.
+     */
+    nextUntil(element?: Element, filter?: string): JQuery;
+    /**
+     * Get all following siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object passed.
+     * 
+     * @param obj A DOM node or jQuery object indicating where to stop matching following sibling elements.
+     * @param filter A string containing a selector expression to match elements against.
+     */
+    nextUntil(obj?: JQuery, filter?: string): JQuery;
+
+    /**
+     * Remove elements from the set of matched elements.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    not(selector: string): JQuery;
+    /**
+     * Remove elements from the set of matched elements.
+     * 
+     * @param func A function used as a test for each element in the set. this is the current DOM element.
+     */
+    not(func: (index: number, element: Element) => boolean): JQuery;
+    /**
+     * Remove elements from the set of matched elements.
+     * 
+     * @param elements One or more DOM elements to remove from the matched set.
+     */
+    not(elements: Element|Element[]): JQuery;
+    /**
+     * Remove elements from the set of matched elements.
+     * 
+     * @param obj An existing jQuery object to match the current set of elements against.
+     */
+    not(obj: JQuery): JQuery;
+
+    /**
+     * Get the closest ancestor element that is positioned.
+     */
+    offsetParent(): JQuery;
+
+    /**
+     * Get the parent of each element in the current set of matched elements, optionally filtered by a selector.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    parent(selector?: string): JQuery;
+
+    /**
+     * Get the ancestors of each element in the current set of matched elements, optionally filtered by a selector.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    parents(selector?: string): JQuery;
+
+    /**
+     * Get the ancestors of each element in the current set of matched elements, up to but not including the element matched by the selector, DOM node, or jQuery object.
+     * 
+     * @param selector A string containing a selector expression to indicate where to stop matching ancestor elements.
+     * @param filter A string containing a selector expression to match elements against.
+     */
+    parentsUntil(selector?: string, filter?: string): JQuery;
+    /**
+     * Get the ancestors of each element in the current set of matched elements, up to but not including the element matched by the selector, DOM node, or jQuery object.
+     * 
+     * @param element A DOM node or jQuery object indicating where to stop matching ancestor elements.
+     * @param filter A string containing a selector expression to match elements against.
+     */
+    parentsUntil(element?: Element, filter?: string): JQuery;
+    /**
+     * Get the ancestors of each element in the current set of matched elements, up to but not including the element matched by the selector, DOM node, or jQuery object.
+     * 
+     * @param obj A DOM node or jQuery object indicating where to stop matching ancestor elements.
+     * @param filter A string containing a selector expression to match elements against.
+     */
+    parentsUntil(obj?: JQuery, filter?: string): JQuery;
+
+    /**
+     * Get the immediately preceding sibling of each element in the set of matched elements, optionally filtered by a selector.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    prev(selector?: string): JQuery;
+
+    /**
+     * Get all preceding siblings of each element in the set of matched elements, optionally filtered by a selector.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    prevAll(selector?: string): JQuery;
+
+    /**
+     * Get all preceding siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object.
+     * 
+     * @param selector A string containing a selector expression to indicate where to stop matching preceding sibling elements.
+     * @param filter A string containing a selector expression to match elements against.
+     */
+    prevUntil(selector?: string, filter?: string): JQuery;
+    /**
+     * Get all preceding siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object.
+     * 
+     * @param element A DOM node or jQuery object indicating where to stop matching preceding sibling elements.
+     * @param filter A string containing a selector expression to match elements against.
+     */
+    prevUntil(element?: Element, filter?: string): JQuery;
+    /**
+     * Get all preceding siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object.
+     * 
+     * @param obj A DOM node or jQuery object indicating where to stop matching preceding sibling elements.
+     * @param filter A string containing a selector expression to match elements against.
+     */
+    prevUntil(obj?: JQuery, filter?: string): JQuery;
+
+    /**
+     * Get the siblings of each element in the set of matched elements, optionally filtered by a selector.
+     * 
+     * @param selector A string containing a selector expression to match elements against.
+     */
+    siblings(selector?: string): JQuery;
+
+    /**
+     * Reduce the set of matched elements to a subset specified by a range of indices.
+     * 
+     * @param start An integer indicating the 0-based position at which the elements begin to be selected. If negative, it indicates an offset from the end of the set.
+     * @param end An integer indicating the 0-based position at which the elements stop being selected. If negative, it indicates an offset from the end of the set. If omitted, the range continues until the end of the set.
+     */
+    slice(start: number, end?: number): JQuery;
+
+    /**
+     * Show the queue of functions to be executed on the matched elements.
+     * 
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     */
+    queue(queueName?: string): any[];
+    /**
+     * Manipulate the queue of functions to be executed, once for each matched element.
+     * 
+     * @param newQueue An array of functions to replace the current queue contents.
+     */
+    queue(newQueue: Function[]): JQuery;
+    /**
+     * Manipulate the queue of functions to be executed, once for each matched element.
+     * 
+     * @param callback The new function to add to the queue, with a function to call that will dequeue the next item.
+     */
+    queue(callback: Function): JQuery;
+    /**
+     * Manipulate the queue of functions to be executed, once for each matched element.
+     * 
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @param newQueue An array of functions to replace the current queue contents.
+     */
+    queue(queueName: string, newQueue: Function[]): JQuery;
+    /**
+     * Manipulate the queue of functions to be executed, once for each matched element.
+     * 
+     * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @param callback The new function to add to the queue, with a function to call that will dequeue the next item.
+     */
+    queue(queueName: string, callback: Function): JQuery;
+}
+declare module "jquery" {
+    export = $;
+}
+declare var jQuery: JQueryStatic;
+declare var $: JQueryStatic;

--- a/typings/moment/moment-node.d.ts
+++ b/typings/moment/moment-node.d.ts
@@ -1,0 +1,479 @@
+// Type definitions for Moment.js 2.8.0
+// Project: https://github.com/timrwood/moment
+// Definitions by: Michael Lakerveld <https://github.com/Lakerfield>, Aaron King <https://github.com/kingdango>, Hiroki Horiuchi <https://github.com/horiuchi>, Dick van den Brink <https://github.com/DickvdBrink>, Adi Dahiya <https://github.com/adidahiya>, Matt Brooks <https://github.com/EnableSoftware>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module moment {
+
+    interface MomentInput {
+        /** Year */
+        years?: number;
+        /** Year */
+        year?: number;
+        /** Year */
+        y?: number;
+
+        /** Month */
+        months?: number;
+        /** Month */
+        month?: number;
+        /** Month */
+        M?: number;
+
+        /** Week */
+        weeks?: number;
+        /** Week */
+        week?: number;
+        /** Week */
+        w?: number;
+
+        /** Day/Date */
+        days?: number;
+        /** Day/Date */
+        day?: number;
+        /** Day/Date */
+        date?: number;
+        /** Day/Date */
+        d?: number;
+
+        /** Hour */
+        hours?: number;
+        /** Hour */
+        hour?: number;
+        /** Hour */
+        h?: number;
+
+        /** Minute */
+        minutes?: number;
+        /** Minute */
+        minute?: number;
+        /** Minute */
+        m?: number;
+
+        /** Second */
+        seconds?: number;
+        /** Second */
+        second?: number;
+        /** Second */
+        s?: number;
+
+        /** Millisecond */
+        milliseconds?: number;
+        /** Millisecond */
+        millisecond?: number;
+        /** Millisecond */
+        ms?: number;
+    }
+
+    interface Duration {
+        humanize(withSuffix?: boolean): string;
+
+        as(units: string): number;
+
+        milliseconds(): number;
+        asMilliseconds(): number;
+
+        seconds(): number;
+        asSeconds(): number;
+
+        minutes(): number;
+        asMinutes(): number;
+
+        hours(): number;
+        asHours(): number;
+
+        days(): number;
+        asDays(): number;
+
+        months(): number;
+        asMonths(): number;
+
+        years(): number;
+        asYears(): number;
+
+        add(n: number, p: string): Duration;
+        add(n: number): Duration;
+        add(d: Duration): Duration;
+
+        subtract(n: number, p: string): Duration;
+        subtract(n: number): Duration;
+        subtract(d: Duration): Duration;
+
+        toISOString(): string;
+        toJSON(): string;
+    }
+
+    interface Moment {
+        format(format: string): string;
+        format(): string;
+
+        fromNow(withoutSuffix?: boolean): string;
+
+        startOf(unitOfTime: string): Moment;
+        endOf(unitOfTime: string): Moment;
+
+        /**
+         * Mutates the original moment by adding time. (deprecated in 2.8.0)
+         *
+         * @param unitOfTime the unit of time you want to add (eg "years" / "hours" etc)
+         * @param amount the amount you want to add
+         */
+        add(unitOfTime: string, amount: number): Moment;
+        /**
+         * Mutates the original moment by adding time.
+         *
+         * @param amount the amount you want to add
+         * @param unitOfTime the unit of time you want to add (eg "years" / "hours" etc)
+         */
+        add(amount: number, unitOfTime: string): Moment;
+        /**
+         * Mutates the original moment by adding time. Note that the order of arguments can be flipped.
+         *
+         * @param amount the amount you want to add
+         * @param unitOfTime the unit of time you want to add (eg "years" / "hours" etc)
+         */
+        add(amount: string, unitOfTime: string): Moment;
+        /**
+         * Mutates the original moment by adding time.
+         *
+         * @param objectLiteral an object literal that describes multiple time units {days:7,months:1}
+         */
+        add(objectLiteral: MomentInput): Moment;
+        /**
+         * Mutates the original moment by adding time.
+         *
+         * @param duration a length of time
+         */
+        add(duration: Duration): Moment;
+
+        /**
+         * Mutates the original moment by subtracting time. (deprecated in 2.8.0)
+         *
+         * @param unitOfTime the unit of time you want to subtract (eg "years" / "hours" etc)
+         * @param amount the amount you want to subtract
+         */
+        subtract(unitOfTime: string, amount: number): Moment;
+        /**
+         * Mutates the original moment by subtracting time.
+         *
+         * @param unitOfTime the unit of time you want to subtract (eg "years" / "hours" etc)
+         * @param amount the amount you want to subtract
+         */
+        subtract(amount: number, unitOfTime: string): Moment;
+        /**
+         * Mutates the original moment by subtracting time. Note that the order of arguments can be flipped.
+         *
+         * @param amount the amount you want to add
+         * @param unitOfTime the unit of time you want to subtract (eg "years" / "hours" etc)
+         */
+        subtract(amount: string, unitOfTime: string): Moment;
+        /**
+         * Mutates the original moment by subtracting time.
+         *
+         * @param objectLiteral an object literal that describes multiple time units {days:7,months:1}
+         */
+        subtract(objectLiteral: MomentInput): Moment;
+        /**
+         * Mutates the original moment by subtracting time.
+         *
+         * @param duration a length of time
+         */
+        subtract(duration: Duration): Moment;
+
+        calendar(): string;
+        calendar(start: Moment): string;
+        calendar(start: Moment, formats: MomentCalendar): string;
+
+        clone(): Moment;
+
+        /**
+         * @return Unix timestamp, or milliseconds since the epoch.
+         */
+        valueOf(): number;
+
+        local(): Moment; // current date/time in local mode
+
+        utc(): Moment; // current date/time in UTC mode
+
+        isValid(): boolean;
+        invalidAt(): number;
+
+        year(y: number): Moment;
+        year(): number;
+        quarter(): number;
+        quarter(q: number): Moment;
+        month(M: number): Moment;
+        month(M: string): Moment;
+        month(): number;
+        day(d: number): Moment;
+        day(d: string): Moment;
+        day(): number;
+        date(d: number): Moment;
+        date(): number;
+        hour(h: number): Moment;
+        hour(): number;
+        hours(h: number): Moment;
+        hours(): number;
+        minute(m: number): Moment;
+        minute(): number;
+        minutes(m: number): Moment;
+        minutes(): number;
+        second(s: number): Moment;
+        second(): number;
+        seconds(s: number): Moment;
+        seconds(): number;
+        millisecond(ms: number): Moment;
+        millisecond(): number;
+        milliseconds(ms: number): Moment;
+        milliseconds(): number;
+        weekday(): number;
+        weekday(d: number): Moment;
+        isoWeekday(): number;
+        isoWeekday(d: number): Moment;
+        weekYear(): number;
+        weekYear(d: number): Moment;
+        isoWeekYear(): number;
+        isoWeekYear(d: number): Moment;
+        week(): number;
+        week(d: number): Moment;
+        weeks(): number;
+        weeks(d: number): Moment;
+        isoWeek(): number;
+        isoWeek(d: number): Moment;
+        isoWeeks(): number;
+        isoWeeks(d: number): Moment;
+        weeksInYear(): number;
+        isoWeeksInYear(): number;
+        dayOfYear(): number;
+        dayOfYear(d: number): Moment;
+
+        from(f: Moment|string|number|Date|number[], suffix?: boolean): string;
+        to(f: Moment|string|number|Date|number[], suffix?: boolean): string;
+        toNow(withoutPrefix?: boolean): string;
+
+        diff(b: Moment): number;
+        diff(b: Moment, unitOfTime: string): number;
+        diff(b: Moment, unitOfTime: string, round: boolean): number;
+
+        toArray(): number[];
+        toDate(): Date;
+        toISOString(): string;
+        toJSON(): string;
+        unix(): number;
+
+        isLeapYear(): boolean;
+        zone(): number;
+        zone(b: number): Moment;
+        zone(b: string): Moment;
+        utcOffset(): number;
+        utcOffset(b: number): Moment;
+        utcOffset(b: string): Moment;
+        daysInMonth(): number;
+        isDST(): boolean;
+
+        isBefore(): boolean;
+        isBefore(b: Moment|string|number|Date|number[], granularity?: string): boolean;
+
+        isAfter(): boolean;
+        isAfter(b: Moment|string|number|Date|number[], granularity?: string): boolean;
+
+        isSame(b: Moment|string|number|Date|number[], granularity?: string): boolean;
+        isBetween(a: Moment|string|number|Date|number[], b: Moment|string|number|Date|number[], granularity?: string): boolean;
+
+        // Deprecated as of 2.8.0.
+        lang(language: string): Moment;
+        lang(reset: boolean): Moment;
+        lang(): MomentLanguage;
+
+        locale(language: string): Moment;
+        locale(reset: boolean): Moment;
+        locale(): string;
+
+        localeData(language: string): Moment;
+        localeData(reset: boolean): Moment;
+        localeData(): MomentLanguage;
+
+        // Deprecated as of 2.7.0.
+        max(date: Moment|string|number|Date|any[]): Moment;
+        max(date: string, format: string): Moment;
+
+        // Deprecated as of 2.7.0.
+        min(date: Moment|string|number|Date|any[]): Moment;
+        min(date: string, format: string): Moment;
+
+        get(unit: string): number;
+        set(unit: string, value: number): Moment;
+        set(objectLiteral: MomentInput): Moment;
+    }
+
+    type formatFunction = () => string;
+
+    interface MomentCalendar {
+      lastDay?: string | formatFunction;
+      sameDay?: string | formatFunction;
+      nextDay?: string | formatFunction;
+      lastWeek?: string | formatFunction;
+      nextWeek?: string | formatFunction;
+      sameElse?: string | formatFunction;
+    }
+
+    interface BaseMomentLanguage {
+        months ?: any;
+        monthsShort ?: any;
+        weekdays ?: any;
+        weekdaysShort ?: any;
+        weekdaysMin ?: any;
+        relativeTime ?: MomentRelativeTime;
+        meridiem ?: (hour: number, minute: number, isLowercase: boolean) => string;
+        calendar ?: MomentCalendar;
+        ordinal ?: (num: number) => string;
+    }
+
+    interface MomentLanguage extends BaseMomentLanguage {
+      longDateFormat?: MomentLongDateFormat;
+    }
+
+    interface MomentLanguageData extends BaseMomentLanguage {
+        /**
+         * @param formatType should be L, LL, LLL, LLLL.
+         */
+        longDateFormat(formatType: string): string;
+    }
+
+    interface MomentLongDateFormat {
+      L: string;
+      LL: string;
+      LLL: string;
+      LLLL: string;
+      LT: string;
+      LTS: string;
+      l?: string;
+      ll?: string;
+      lll?: string;
+      llll?: string;
+      lt?: string;
+      lts?: string;
+    }
+
+    interface MomentRelativeTime {
+      future: any;
+      past: any;
+      s: any;
+      m: any;
+      mm: any;
+      h: any;
+      hh: any;
+      d: any;
+      dd: any;
+      M: any;
+      MM: any;
+      y: any;
+      yy: any;
+    }
+
+    interface MomentStatic {
+        version: string;
+        fn: Moment;
+
+        (): Moment;
+        (date: number): Moment;
+        (date: number[]): Moment;
+        (date: string, format?: string, strict?: boolean): Moment;
+        (date: string, format?: string, language?: string, strict?: boolean): Moment;
+        (date: string, formats: string[], strict?: boolean): Moment;
+        (date: string, formats: string[], language?: string, strict?: boolean): Moment;
+        (date: string, specialFormat: () => void, strict?: boolean): Moment;
+        (date: string, specialFormat: () => void, language?: string, strict?: boolean): Moment;
+        (date: string, formatsIncludingSpecial: any[], strict?: boolean): Moment;
+        (date: string, formatsIncludingSpecial: any[], language?: string, strict?: boolean): Moment;
+        (date: Date): Moment;
+        (date: Moment): Moment;
+        (date: Object): Moment;
+
+        utc(): Moment;
+        utc(date: number): Moment;
+        utc(date: number[]): Moment;
+        utc(date: string, format?: string, strict?: boolean): Moment;
+        utc(date: string, format?: string, language?: string, strict?: boolean): Moment;
+        utc(date: string, formats: string[], strict?: boolean): Moment;
+        utc(date: string, formats: string[], language?: string, strict?: boolean): Moment;
+        utc(date: Date): Moment;
+        utc(date: Moment): Moment;
+        utc(date: Object): Moment;
+
+        unix(timestamp: number): Moment;
+
+        invalid(parsingFlags?: Object): Moment;
+        isMoment(): boolean;
+        isMoment(m: any): boolean;
+        isDate(m: any): boolean;
+        isDuration(): boolean;
+        isDuration(d: any): boolean;
+
+        // Deprecated in 2.8.0.
+        lang(language?: string): string;
+        lang(language?: string, definition?: MomentLanguage): string;
+
+        locale(language?: string): string;
+        locale(language?: string[]): string;
+        locale(language?: string, definition?: MomentLanguage): string;
+
+        localeData(language?: string): MomentLanguageData;
+
+        longDateFormat: any;
+        relativeTime: any;
+        meridiem: (hour: number, minute: number, isLowercase: boolean) => string;
+        calendar: any;
+        ordinal: (num: number) => string;
+
+        duration(milliseconds: Number): Duration;
+        duration(num: Number, unitOfTime: string): Duration;
+        duration(input: MomentInput): Duration;
+        duration(object: any): Duration;
+        duration(): Duration;
+
+        parseZone(date: string): Moment;
+
+        months(): string[];
+        months(index: number): string;
+        months(format: string): string[];
+        months(format: string, index: number): string;
+        monthsShort(): string[];
+        monthsShort(index: number): string;
+        monthsShort(format: string): string[];
+        monthsShort(format: string, index: number): string;
+
+        weekdays(): string[];
+        weekdays(index: number): string;
+        weekdays(format: string): string[];
+        weekdays(format: string, index: number): string;
+        weekdaysShort(): string[];
+        weekdaysShort(index: number): string;
+        weekdaysShort(format: string): string[];
+        weekdaysShort(format: string, index: number): string;
+        weekdaysMin(): string[];
+        weekdaysMin(index: number): string;
+        weekdaysMin(format: string): string[];
+        weekdaysMin(format: string, index: number): string;
+
+        min(...moments: Moment[]): Moment;
+        max(...moments: Moment[]): Moment;
+
+        normalizeUnits(unit: string): string;
+        relativeTimeThreshold(threshold: string): number|boolean;
+        relativeTimeThreshold(threshold: string, limit:number): boolean;
+
+        /**
+         * Constant used to enable explicit ISO_8601 format parsing.
+         */
+        ISO_8601(): void;
+
+        defaultFormat: string;
+    }
+
+}
+
+declare module 'moment' {
+    var moment: moment.MomentStatic;
+    export = moment;
+}

--- a/typings/moment/moment.d.ts
+++ b/typings/moment/moment.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for Moment.js 2.8.0
+// Project: https://github.com/timrwood/moment
+// Definitions by: Michael Lakerveld <https://github.com/Lakerfield>, Aaron King <https://github.com/kingdango>, Hiroki Horiuchi <https://github.com/horiuchi>, Dick van den Brink <https://github.com/DickvdBrink>, Adi Dahiya <https://github.com/adidahiya>, Matt Brooks <https://github.com/EnableSoftware>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="moment-node.d.ts" />
+
+declare var moment: moment.MomentStatic;

--- a/typings/numeral/numeral.d.ts
+++ b/typings/numeral/numeral.d.ts
@@ -1,0 +1,1 @@
+declare var numeral: any;

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,0 +1,3 @@
+
+/// <reference path="jquery/jquery.d.ts" />
+/// <reference path="jquery.dataTables/jquery.dataTables.d.ts" />

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,3 +1,5 @@
 
 /// <reference path="jquery/jquery.d.ts" />
 /// <reference path="jquery.dataTables/jquery.dataTables.d.ts" />
+/// <reference path="moment/moment.d.ts" />
+/// <reference path="moment/moment-node.d.ts" />


### PR DESCRIPTION
I migrated StatisticsParser to TypeScript and wrote up a play-by-play.  It was more work than usual due to using a few older JS libraries/older syntax that don't have current definitions on DefinitelyTyped.  Only 4 lines actually changed in `statsioparser.ts` (JS).

Play-by-play here: https://github.com/nycdotnet/StatisticsParser/blob/ImplementTypeScript/TypeScript%20Implementation.md
