### PR TITLE
Provide clearance for the 1st parsed line

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -97,6 +97,7 @@
         </form>
 
         <p>&nbsp;</p>
+        <p>&nbsp;</p>
         <div id="resultTotal"></div>
         <div id="result"></div>
     </div>


### PR DESCRIPTION
Fixes the problem where the first line of parsed text gets shifted to the right by the Chunky Bootstrap Buttons.

To replicate the current problem, try parsing:

Line 1
Line 2
Line 3

The first line will get pushed to the right of the Parse button.